### PR TITLE
Use private ip if the public ip is nil

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -48,7 +48,7 @@ module Kitchen
 
         info("EC2 instance <#{state[:server_id]}> created.")
         server.wait_for { print "."; ready? } ; print "(server ready)"
-        state[:hostname] = server.public_ip_address ||= server.private_ip_address
+        state[:hostname] = server.public_ip_address || server.private_ip_address
         wait_for_sshd(state[:hostname])      ; print "(ssh ready)\n"
         debug("ec2:create '#{state[:hostname]}'")
       rescue Fog::Errors::Error, Excon::Errors::Error => ex


### PR DESCRIPTION
Instances created within a VPC do not have a public ip address by default.  test-kitchen currently relies on the public ip and saves an empty string if it is nil.  This patch uses the private ip if the public ip is not available.
