### PR TITLE
In VPC groups must be specified by setting :security_group_ids rather than :groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The EC2 [instance type][instance_docs] (also known as size) to use.
 
 The default is `"m1.small"`.
 
-### <a name="config-groups"></a> groups
+### <a name="config-security_group_ids"></a> security_group_ids
 
-An Array of EC [security groups][group_docs] which will be applied to the
+An Array of EC2 [security groups][group_docs] which will be applied to the
 instance.
 
 The default is `["default"]`.
@@ -182,6 +182,7 @@ driver_config:
   aws_secret_access_key: 3UK...
   aws_ssh_key_id: id_rsa-aws
   ssh_key: /path/to/id_rsa-aws
+  security_group_ids: ["sg-1a2b3c4d"]
   region: us-east-1
   availability_zone: us-east-1b
   require_chef_omnibus: true
@@ -212,6 +213,7 @@ driver_config:
   aws_secret_access_key: <%= ENV['AWS_SECRET_KEY'] %>
   aws_ssh_key_id: <%= ENV['AWS_SSH_KEY_ID'] %>
   ssh_key: <%= File.expand_path('~/.ssh/id_rsa') %>
+  security_group_ids: ["sg-1a2b3c4d"]
   region: us-east-1
   availability_zone: us-east-1b
   require_chef_omnibus: true

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -34,7 +34,7 @@ module Kitchen
       default_config :region,             'us-east-1'
       default_config :availability_zone,  'us-east-1b'
       default_config :flavor_id,          'm1.small'
-      default_config :groups,             ['default']
+      default_config :security_group_ids, ['default']
       default_config :tags,               { 'created-by' => 'test-kitchen' }
       default_config :aws_access_key_id do |driver|
         ENV['AWS_ACCESS_KEY']
@@ -105,7 +105,7 @@ module Kitchen
 
         connection.servers.create(
           :availability_zone  => config[:availability_zone],
-          :groups             => config[:groups],
+          :security_group_ids => config[:security_group_ids],
           :tags               => config[:tags],
           :flavor_id          => config[:flavor_id],
           :image_id           => config[:image_id],
@@ -119,7 +119,7 @@ module Kitchen
         debug("ec2:availability_zone '#{config[:availability_zone]}'")
         debug("ec2:flavor_id '#{config[:flavor_id]}'")
         debug("ec2:image_id '#{config[:image_id]}'")
-        debug("ec2:groups '#{config[:groups]}'")
+        debug("ec2:security_group_ids '#{config[:security_group_ids]}'")
         debug("ec2:tags '#{config[:tags]}'")
         debug("ec2:key_name '#{config[:aws_ssh_key_id]}'")
         debug("ec2:subnet_id '#{config[:subnet_id]}'")


### PR DESCRIPTION
This is backwards compatible with non-VPC hosts so, for simplicity's sake, it probably makes sense to just do it this way.
