### PR TITLE
Try to use dns_name before public and private ip address

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -63,7 +63,7 @@ module Kitchen
 
         info("EC2 instance <#{state[:server_id]}> created.")
         server.wait_for { print "."; ready? } ; print "(server ready)"
-        state[:hostname] = server.public_ip_address || server.private_ip_address
+        state[:hostname] = server.dns_name || (server.public_ip_address || server.private_ip_address)
         wait_for_sshd(state[:hostname], config[:username]) ; print "(ssh ready)\n"
         debug("ec2:create '#{state[:hostname]}'")
       rescue Fog::Errors::Error, Excon::Errors::Error => ex


### PR DESCRIPTION
Uses public dns name over public and private ip addresses.  Would solve issue addressed in #14

This may need to be configurable but I think in most cases you would want to use the domain name over public ip.  I'm not familiar with VPC though and I'm not sure how dns_name behaves in that situation.
