### PR TITLE
endpoint should have a trailing slash

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -53,7 +53,7 @@ module Kitchen
         driver.default_username
       end
       default_config :endpoint do |driver|
-        "https://ec2.#{driver[:region]}.amazonaws.com"
+        "https://ec2.#{driver[:region]}.amazonaws.com/"
       end
 
       required_config :aws_access_key_id


### PR DESCRIPTION
per https://github.com/fog/fog/issues/583

This fixes the error from kitchen run 

```
>>>>>> Message: SignatureDoesNotMatch => The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
```
