### PR TITLE
Added User Data option for running scripts to install dependencies or artifacts before chef runs or kitchen-ec2 provisions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ The default will be determined by the Platform name, if a default exists (see
 [amis.json][amis_json]). If a default cannot be computed, then the default is
 `"root"`.
 
+### <a name="config-user-data"></a> user\_data
+
+Path to the user data script to feed the instance. Use bash to install dependencies or download artifacts before chef runs.
+
+The default is unset, or `nil`.
+
 ## <a name="example"></a> Example
 
 The following could be used in a `.kitchen.yml` or in a `.kitchen.local.yml`

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -37,6 +37,7 @@ module Kitchen
       default_config :ebs_optimized,      false
       default_config :security_group_ids, ['default']
       default_config :tags,               { 'created-by' => 'test-kitchen' }
+      default_config :user_data,          nil
       default_config :aws_access_key_id do |driver|
         ENV['AWS_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY_ID']
       end
@@ -119,6 +120,7 @@ module Kitchen
           :image_id           => config[:image_id],
           :key_name           => config[:aws_ssh_key_id],
           :subnet_id          => config[:subnet_id],
+          :user_data          => (config[:user_data] != nil ? File.read(config[:user_data]) : nil)
         )
       end
 
@@ -132,6 +134,7 @@ module Kitchen
         debug("ec2:tags '#{config[:tags]}'")
         debug("ec2:key_name '#{config[:aws_ssh_key_id]}'")
         debug("ec2:subnet_id '#{config[:subnet_id]}'")
+        debug("ec2:user_data '#{config[:user_data]}'")
       end
 
       def amis


### PR DESCRIPTION
I needed to get an encrypted data bag on-box before chef-zero ran, this is how I did it:

``` yaml
user_data: ./user-data.sh
```

``` bash
#!/bin/bash

########## Echo a small python script to download S3 Artifacts ##########
echo "#!/usr/bin/python
import boto
from boto.s3.connection import S3Connection
s3 = S3Connection()
bucket = s3.get_bucket('aws-chef-bucket')
key = bucket.get_key('chef/encrypted_data_bag_secret')
key.get_contents_to_filename('/etc/chef/.secret')" >> /tmp/secrets.py

########## Install Python/Boto and run the script #######################
sudo yum install python python-boto
mkdir /etc/chef
python /tmp/secrets.py
```
