### PR TITLE
Support AWS session tokens for use with IAM roles.

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -43,6 +43,9 @@ module Kitchen
       default_config :aws_secret_access_key do |driver|
         ENV['AWS_SECRET_KEY'] || ENV['AWS_SECRET_ACCESS_KEY']
       end
+      default_config :aws_session_token do |driver|
+        ENV['AWS_SESSION_TOKEN'] || ENV['AWS_TOKEN']
+      end
       default_config :aws_ssh_key_id do |driver|
         ENV['AWS_SSH_KEY_ID']
       end
@@ -102,6 +105,7 @@ module Kitchen
           :provider               => :aws,
           :aws_access_key_id      => config[:aws_access_key_id],
           :aws_secret_access_key  => config[:aws_secret_access_key],
+          :aws_session_token      => config[:aws_session_token],
           :region                 => config[:region],
           :endpoint               => config[:endpoint],
         )


### PR DESCRIPTION
Pretty self-explanatory. AWS sucks for making extra magic auth data for seemingly no reason.
