### PR TITLE
add retry on request-limit-exceeded error

### DIFF
--- a/lib/kitchen/driver/retry.rb
+++ b/lib/kitchen/driver/retry.rb
@@ -6,7 +6,7 @@ module Kitchen
   module Retry
 
     def with_retry_on_throttling(options = {}, &block)
-      raise "block is required" unless block_given?
+      raise 'block is required' unless block_given?
       retries = 0
       max_retries = options[:max_retries] || 10
       retry_delay = options[:retry_delay] || 3
@@ -18,24 +18,23 @@ module Kitchen
           r = yield retries
           success = true
         rescue ::Fog::Compute::AWS::Error => e
-          if e.message =~ /RequestLimitExceeded/
-            success = false
-            if max_retries - retries > 0
-              delay = retry_delay * (retry_backoff ** retries)
-              delay = delay.to_i
-              puts e.message
-              puts "Sleeping %0.2f seconds. Will retry %i more time(s)." % [delay, max_retries - retries]
-              sleep delay
-            end
-            retries += 1
-          else
-            raise e
-          end
+          raise e unless e.message =~ /RequestLimitExceeded/
+          on_throttled(max_retries, retries, retry_delay, retry_backoff)
+          retries += 1
         end
       end until success or retries > max_retries
       raise e unless success
       r
     end
+
+    def on_throttled(max_retries, retries, retry_delay, retry_backoff)
+      if max_retries - retries > 0
+        delay = retry_delay * (retry_backoff ** retries)
+        delay = delay.to_i
+        msg = 'Sleeping %0.2f seconds. Will retry %i more time(s).'
+        puts msg % [delay, max_retries - retries]
+        sleep delay
+      end
+    end
   end
 end
-

--- a/lib/kitchen/driver/retry.rb
+++ b/lib/kitchen/driver/retry.rb
@@ -1,0 +1,41 @@
+require 'fog'
+
+module Kitchen
+  # Provide a method to retry operations when API requests failed
+  # due to throtlling.
+  module Retry
+
+    def with_retry_on_throttling(options = {}, &block)
+      raise "block is required" unless block_given?
+      retries = 0
+      max_retries = options[:max_retries] || 10
+      retry_delay = options[:retry_delay] || 3
+      retry_backoff = 1.4142 + Random.rand
+      success = false
+      r = e = nil
+      begin
+        begin
+          r = yield retries
+          success = true
+        rescue ::Fog::Compute::AWS::Error => e
+          if e.message =~ /RequestLimitExceeded/
+            success = false
+            if max_retries - retries > 0
+              delay = retry_delay * (retry_backoff ** retries)
+              delay = delay.to_i
+              puts e.message
+              puts "Sleeping %0.2f seconds. Will retry %i more time(s)." % [delay, max_retries - retries]
+              sleep delay
+            end
+            retries += 1
+          else
+            raise e
+          end
+        end
+      end until success or retries > max_retries
+      raise e unless success
+      r
+    end
+  end
+end
+

--- a/spec/create_spec.rb
+++ b/spec/create_spec.rb
@@ -1,10 +1,11 @@
+require 'kitchen/driver/retry'
 require 'kitchen/driver/ec2'
 require 'kitchen/provisioner/dummy'
 
 describe Kitchen::Driver::Ec2 do
 
     let(:config) do
-      {}
+      { :aws_ssh_key_id => 'foo', :aws_secret_access_key=>'foo',:aws_access_key_id=> 'foo'}
     end
 
     let(:state) do

--- a/spec/retry_spec.rb
+++ b/spec/retry_spec.rb
@@ -9,9 +9,9 @@ describe Kitchen::Retry do
   end
 
   it 'should retry on RequestLimitExceeded' do
-    o.should_receive(:puts).with('RequestLimitExceeded => Request limit exceeded.')
-    o.should_receive(:puts).with('Sleeping 1.00 seconds. Will retry 1 more time(s).')
-    o.with_retry_on_throttling(:max_retries => 1, :retry_delay => 1) do
+    o.stub(:on_throttled)
+    o.should_receive(:on_throttled).twice
+    o.with_retry_on_throttling(:max_retries => 1) do
         raise ::Fog::Compute::AWS::Error.new('RequestLimitExceeded => Request limit exceeded.')
       end rescue nil
   end

--- a/spec/retry_spec.rb
+++ b/spec/retry_spec.rb
@@ -1,0 +1,19 @@
+require 'kitchen/driver/retry'
+
+
+describe Kitchen::Retry do
+  let(:o) do
+    Class.new do
+      include Kitchen::Retry
+    end.new
+  end
+
+  it 'should retry on RequestLimitExceeded' do
+    o.should_receive(:puts).with('RequestLimitExceeded => Request limit exceeded.')
+    o.should_receive(:puts).with('Sleeping 1.00 seconds. Will retry 1 more time(s).')
+    o.with_retry_on_throttling(:max_retries => 1, :retry_delay => 1) do
+        raise ::Fog::Compute::AWS::Error.new('RequestLimitExceeded => Request limit exceeded.')
+      end rescue nil
+  end
+
+end


### PR DESCRIPTION
When running TestKitchen with many suites in parallel, the requests to EC2 might get throttled, causing TestKitchen to fail.

This pull request adds a retry mechanism on `create_server` and `destroy_server`.
