### PR TITLE
Don't create multiple instances if "kitchen create" is called multiple t...

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -67,6 +67,7 @@ module Kitchen
       required_config :image_id
 
       def create(state)
+        return if state[:server_id]
         server = create_server
         state[:server_id] = server.id
 


### PR DESCRIPTION
...imes.

Calling "kitchen create" multiple times in succession will result in multiple identical instances being launched, with test-kitchen losing track of the earlier instance(s):

```
$ bundle exec kitchen create
-----> Starting Kitchen (v1.2.1)
-----> Creating <default-ubuntu-1204>...
       EC2 instance <i-80588588> created.
................................       (server ready)
       Waiting for ec2-54-188-228-88.us-west-2.compute.amazonaws.com:22...
       Waiting for ec2-54-188-228-88.us-west-2.compute.amazonaws.com:22...
       Waiting for ec2-54-188-228-88.us-west-2.compute.amazonaws.com:22...
       (ssh ready)\n
       Finished creating <default-ubuntu-1204> (0m58.64s).
-----> Kitchen is finished. (0m59.74s)
$ bundle exec kitchen create
-----> Starting Kitchen (v1.2.1)
-----> Creating <default-ubuntu-1204>...
       EC2 instance <i-76508d7e> created.
...........................       (server ready)
       Waiting for ec2-54-212-23-228.us-west-2.compute.amazonaws.com:22...
       Waiting for ec2-54-212-23-228.us-west-2.compute.amazonaws.com:22...
       (ssh ready)\n
       Finished creating <default-ubuntu-1204> (0m49.24s).
-----> Kitchen is finished. (0m50.36s)
```

This one-liner should fix that - I first noticed this when writing kitchen-gce, but forgot to send a pull request until now (sorry!); thanks for considering this.
