### PR TITLE
refresh ec2 hostname/ip from server id 

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -65,6 +65,11 @@ module Kitchen
       required_config :aws_secret_access_key
       required_config :aws_ssh_key_id
       required_config :image_id
+ 
+      def initialize(config = {})
+        super
+        @hostname_refreshed = false 
+      end
 
       def create(state)
         return if state[:server_id]
@@ -99,6 +104,11 @@ module Kitchen
 
       def default_username
         amis['usernames'][instance.platform.name] || 'root'
+      end
+
+      def build_ssh_args(state)
+        refresh_host_if_needed(state)
+        super
       end
 
       private
@@ -168,6 +178,16 @@ module Kitchen
         else
           server.dns_name || server.public_ip_address || server.private_ip_address
         end
+      end
+      
+      # At most once per driver lifetime, use the ec2 instance identity to find out the hostname/ip
+      # Motivation: for converge/verify hack cycles, developer may have stopped/started the EC2 instance eg. overnight
+      def refresh_host_if_needed(state)
+        return if @hostname_refreshed || state[:server_id].nil?
+        server = connection.servers.get(state[:server_id])
+        return if server.nil?
+        state[:hostname] = hostname(server)
+        @hostname_refreshed = true
       end
     end
   end

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -65,10 +65,10 @@ module Kitchen
       required_config :aws_secret_access_key
       required_config :aws_ssh_key_id
       required_config :image_id
- 
+
       def initialize(config = {})
         super
-        @hostname_refreshed = false 
+        @hostname_refreshed = false
       end
 
       def create(state)
@@ -179,9 +179,10 @@ module Kitchen
           server.dns_name || server.public_ip_address || server.private_ip_address
         end
       end
-      
+
       # At most once per driver lifetime, use the ec2 instance identity to find out the hostname/ip
-      # Motivation: for converge/verify hack cycles, developer may have stopped/started the EC2 instance eg. overnight
+      # Motivation: for converge/verify hack cycles, developer may have stopped/started the EC2
+      # instance eg. overnight
       def refresh_host_if_needed(state)
         return if @hostname_refreshed || state[:server_id].nil?
         server = connection.servers.get(state[:server_id])


### PR DESCRIPTION
This change will refresh the EC2 instance hostname/ip immediately prior to the first ssh connection setup for the driver lifetime.

I see test-kitchen used in 2 complementary ways - full CI on the one hand, and developer converge/verify hacking on the other. This change is targeted at the latter. 

The change solves a problem where (to save $$$) the developer stop the EC2 instance before going home and start it again in the morning to resume work. Because EC2 assigns a new public ip when the instance is restarted, it would break kitchen-ec2 because the public ip stored in the state file would never be updated. 

This change doesn't fix the state file not being updated - so 'kitchen diagnose' will show incorrect information. Fixing this would need a change to test-kitchen/test-kitchen.
