### PR TITLE
add associate_public_ip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ For specific default values, please consult [amis.json][amis_json].
 
 ## <a name="config"></a> Configuration
 
+### <a name="config-associate-public-ap"></a> associate\_public\_ip
+
+Instances created within a [Virtual Private Cloud (VPC)][vpc_docs] will not
+automatically have a public IP address allocated. Set this option to `true` to
+allocate a public IP and associate it with the launched instance.
+
+Note that this setting has no effect on instances launched into EC2-Classic
+(i.e., instances not launched into a VPC).
+
+The default is `false`.
+
 ### <a name="config-az"></a> availability\_zone
 
 **Required** The AWS [availability zone][region_docs] to use.
@@ -283,3 +294,4 @@ Apache 2.0 (see [LICENSE][license])
 [kitchenci]:        http://kitchen.ci/
 [region_docs]:      http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
 [subnet_docs]:      http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html
+[vpc_docs]:         http://docs.aws.amazon.com/AmazonVPC/latest/GettingStartedGuide/ExerciseOverview.html

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -30,13 +30,14 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Ec2 < Kitchen::Driver::SSHBase
 
-      default_config :region,             'us-east-1'
-      default_config :availability_zone,  'us-east-1b'
-      default_config :flavor_id,          'm1.small'
-      default_config :ebs_optimized,      false
-      default_config :security_group_ids, ['default']
-      default_config :tags,               { 'created-by' => 'test-kitchen' }
-      default_config :iam_profile_name,   nil
+      default_config :region,              'us-east-1'
+      default_config :availability_zone,   'us-east-1b'
+      default_config :flavor_id,           'm1.small'
+      default_config :ebs_optimized,       false
+      default_config :security_group_ids,  ['default']
+      default_config :tags,                { 'created-by' => 'test-kitchen' }
+      default_config :iam_profile_name,    nil
+      default_config :associate_public_ip, false
       default_config :aws_access_key_id do |driver|
         ENV['AWS_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY_ID']
       end
@@ -118,6 +119,7 @@ module Kitchen
         debug_server_config
 
         connection.servers.create(
+          :associate_public_ip       => config[:associate_public_ip],
           :availability_zone         => config[:availability_zone],
           :security_group_ids        => config[:security_group_ids],
           :tags                      => config[:tags],
@@ -132,6 +134,7 @@ module Kitchen
 
       def debug_server_config
         debug("ec2:region '#{config[:region]}'")
+        debug("ec2:associate_public_ip '#{config[:associate_public_ip]}'")
         debug("ec2:availability_zone '#{config[:availability_zone]}'")
         debug("ec2:flavor_id '#{config[:flavor_id]}'")
         debug("ec2:ebs_optimized '#{config[:ebs_optimized]}'")


### PR DESCRIPTION
Instances launched within a VPC do not automatically receive public IP addresses. Add an `associate_public_ip` option to instruct Fog to allocate and assign a public IP to the launched instance.
