### PR TITLE
Eucalyptus: wait for an ip address

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -72,8 +72,12 @@ module Kitchen
         state[:server_id] = server.id
 
         info("EC2 instance <#{state[:server_id]}> created.")
-        server.wait_for { print '.'; ready? }
-        server.wait_for { print '.'; !public_ip_address.nil? and (public_ip_address != '0.0.0.0') }
+        server.wait_for do
+          print '.'
+          ready? and                          # Euca instances often report ready
+            !public_ip_address.nil? and       # before they have an IP
+            (public_ip_address != '0.0.0.0')
+        end
         print '(server ready)'
         state[:hostname] = hostname(server)
         wait_for_sshd(state[:hostname], config[:username])


### PR DESCRIPTION
Euca instances usually return state == running before they have an IP assigned in the cloud controller. This means kitchen-ec2 gets the default (useless) IP of 0.0.0.0, and saves it.

This changes the create step to wait_for the IP to be assigned. Should be no impact on AWS, but I am fine moving this behind a new config option specific to Euca.

As far as I can tell this is the only change needed to make Eucalyptus support work.
