### PR TITLE
Add and update AMIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ platforms:
   - name: ubuntu-13.04
   - name: ubuntu-13.10
   - name: ubuntu-14.04
-  - name: centos-6.4
-  - name: debian-7.1.0
+  - name: centos-6.5
+  - name: fedora-20
+  - name: debian-7.6
 ```
 
 This will effectively generate a configuration similar to:
@@ -51,9 +52,9 @@ platforms:
       image_id: ami-2f115c46
       username: ubuntu
   # ...
-  - name: centos-6.4
+  - name: centos-6.5
     driver:
-      image_id: ami-bf5021d6
+      image_id: ami-8997afe0
       username: root
   # ...
 ```

--- a/data/amis.json
+++ b/data/amis.json
@@ -8,6 +8,7 @@
       "ubuntu-13.10": "ami-45f1a744",
       "ubuntu-14.04": "ami-955c0c94",
       "centos-6.4": "ami-9ffa709e",
+      "fedora-20": "ami-9583fd94",
       "debian-7.1.0": "ami-f1f064f0"
     },
     "ap-southeast-1": {
@@ -18,6 +19,7 @@
       "ubuntu-13.10": "ami-02e6b850",
       "ubuntu-14.04": "ami-9a7c25c8",
       "centos-6.4": "ami-46f5bb14",
+      "fedora-20": "ami-6ceebe3e",
       "debian-7.1.0": "ami-fe8ac3ac"
     },
     "ap-southeast-2": {
@@ -28,6 +30,7 @@
       "ubuntu-13.10": "ami-e54423df",
       "ubuntu-14.04": "ami-f3b1d6c9",
       "centos-6.4": "ami-9352c1a9",
+      "fedora-20": "ami-eba038d1",
       "debian-7.1.0": "ami-4e099a74"
     },
     "eu-west-1": {
@@ -38,6 +41,7 @@
       "ubuntu-13.10": "ami-39eb3f4e",
       "ubuntu-14.04": "ami-c112c5b6",
       "centos-6.4": "ami-75190b01",
+      "fedora-20": "ami-a5ad56d2",
       "debian-7.1.0": "ami-954559e1"
     },
     "sa-east-1": {
@@ -48,6 +52,7 @@
       "ubuntu-13.10": "ami-076cc21a",
       "ubuntu-14.04": "ami-052b8518",
       "centos-6.4": "ami-a665c0bb",
+      "fedora-20": "ami-2345e73e",
       "debian-7.1.0": "ami-b03590ad"
     },
     "us-east-1": {
@@ -58,6 +63,7 @@
       "ubuntu-13.10": "ami-a65393ce",
       "ubuntu-14.04": "ami-4a915c22",
       "centos-6.4": "ami-bf5021d6",
+      "fedora-20": "ami-21362b48",
       "debian-7.1.0": "ami-50d9a439"
     },
     "us-west-1": {
@@ -68,6 +74,7 @@
       "ubuntu-13.10": "ami-bb2a2afe",
       "ubuntu-14.04": "ami-d99a9a9c",
       "centos-6.4": "ami-5d456c18",
+      "fedora-20": "ami-f8f1c8bd",
       "debian-7.1.0": "ami-1a9bb25f"
     },
     "us-west-2": {
@@ -78,6 +85,7 @@
       "ubuntu-13.10": "ami-c18ff1f1",
       "ubuntu-14.04": "ami-b7720b87",
       "centos-6.4": "ami-b3bf2f83",
+      "fedora-20": "ami-cc8de6fc",
       "debian-7.1.0": "ami-158a1925"
     }
   },
@@ -89,11 +97,13 @@
     "ubuntu-13.10": "ubuntu",
     "ubuntu-14.04": "ubuntu",
     "centos-6.4": "root",
+    "fedora-20": "fedora",
     "debian-7.1.0": "admin"
   },
   "references": {
     "ubuntu": "http://uec-images.ubuntu.com/query/",
     "debian": "https://wiki.debian.org/Cloud/AmazonEC2Image",
     "centos": "http://wiki.centos.org/Cloud/AWS"
+    "fedora": "http://fedoraproject.org/get-fedora#clouds"
   }
 }

--- a/data/amis.json
+++ b/data/amis.json
@@ -9,7 +9,7 @@
       "ubuntu-14.04": "ami-955c0c94",
       "centos-6.4": "ami-9ffa709e",
       "fedora-20": "ami-9583fd94",
-      "debian-7.1.0": "ami-f1f064f0"
+      "debian-7.6": "ami-99b8ea98"
     },
     "ap-southeast-1": {
       "ubuntu-10.04": "ami-34713866",
@@ -20,7 +20,7 @@
       "ubuntu-14.04": "ami-9a7c25c8",
       "centos-6.4": "ami-46f5bb14",
       "fedora-20": "ami-6ceebe3e",
-      "debian-7.1.0": "ami-fe8ac3ac"
+      "debian-7.6": "ami-e80a52ba"
     },
     "ap-southeast-2": {
       "ubuntu-10.04": "ami-2f009315",
@@ -31,7 +31,7 @@
       "ubuntu-14.04": "ami-f3b1d6c9",
       "centos-6.4": "ami-9352c1a9",
       "fedora-20": "ami-eba038d1",
-      "debian-7.1.0": "ami-4e099a74"
+      "debian-7.6": "ami-f9c9aec3"
     },
     "eu-west-1": {
       "ubuntu-10.04": "ami-bbadb0cf",
@@ -42,7 +42,7 @@
       "ubuntu-14.04": "ami-c112c5b6",
       "centos-6.4": "ami-75190b01",
       "fedora-20": "ami-a5ad56d2",
-      "debian-7.1.0": "ami-954559e1"
+      "debian-7.6": "ami-89dd0cfe"
     },
     "sa-east-1": {
       "ubuntu-10.04": "ami-962c898b",
@@ -53,7 +53,7 @@
       "ubuntu-14.04": "ami-052b8518",
       "centos-6.4": "ami-a665c0bb",
       "fedora-20": "ami-2345e73e",
-      "debian-7.1.0": "ami-b03590ad"
+      "debian-7.6": "ami-f7d079ea"
     },
     "us-east-1": {
       "ubuntu-10.04": "ami-1ab3ce73",
@@ -64,7 +64,7 @@
       "ubuntu-14.04": "ami-4a915c22",
       "centos-6.4": "ami-bf5021d6",
       "fedora-20": "ami-21362b48",
-      "debian-7.1.0": "ami-50d9a439"
+      "debian-7.6": "ami-f4ad649c"
     },
     "us-west-1": {
       "ubuntu-10.04": "ami-848ba2c1",
@@ -75,7 +75,7 @@
       "ubuntu-14.04": "ami-d99a9a9c",
       "centos-6.4": "ami-5d456c18",
       "fedora-20": "ami-f8f1c8bd",
-      "debian-7.1.0": "ami-1a9bb25f"
+      "debian-7.6": "ami-89dd0cfe"
     },
     "us-west-2": {
       "ubuntu-10.04": "ami-f19407c1",
@@ -86,7 +86,7 @@
       "ubuntu-14.04": "ami-b7720b87",
       "centos-6.4": "ami-b3bf2f83",
       "fedora-20": "ami-cc8de6fc",
-      "debian-7.1.0": "ami-158a1925"
+      "debian-7.6": "ami-476c1477"
     }
   },
   "usernames": {

--- a/data/amis.json
+++ b/data/amis.json
@@ -7,7 +7,7 @@
       "ubuntu-13.04": "ami-97099a96",
       "ubuntu-13.10": "ami-45f1a744",
       "ubuntu-14.04": "ami-955c0c94",
-      "centos-6.4": "ami-9ffa709e",
+      "centos-6.5": "ami-81294380",
       "fedora-20": "ami-9583fd94",
       "debian-7.6": "ami-99b8ea98"
     },
@@ -18,7 +18,7 @@
       "ubuntu-13.04": "ami-4af5bd18",
       "ubuntu-13.10": "ami-02e6b850",
       "ubuntu-14.04": "ami-9a7c25c8",
-      "centos-6.4": "ami-46f5bb14",
+      "centos-6.5": "ami-a08fd9f2",
       "fedora-20": "ami-6ceebe3e",
       "debian-7.6": "ami-e80a52ba"
     },
@@ -29,7 +29,7 @@
       "ubuntu-13.04": "ami-8f32a0b5",
       "ubuntu-13.10": "ami-e54423df",
       "ubuntu-14.04": "ami-f3b1d6c9",
-      "centos-6.4": "ami-9352c1a9",
+      "centos-6.5": "ami-e7138ddd",
       "fedora-20": "ami-eba038d1",
       "debian-7.6": "ami-f9c9aec3"
     },
@@ -40,7 +40,7 @@
       "ubuntu-13.04": "ami-6fd4cf1b",
       "ubuntu-13.10": "ami-39eb3f4e",
       "ubuntu-14.04": "ami-c112c5b6",
-      "centos-6.4": "ami-75190b01",
+      "centos-6.5": "ami-42718735",
       "fedora-20": "ami-a5ad56d2",
       "debian-7.6": "ami-89dd0cfe"
     },
@@ -51,7 +51,7 @@
       "ubuntu-13.04": "ami-4b2b8f56",
       "ubuntu-13.10": "ami-076cc21a",
       "ubuntu-14.04": "ami-052b8518",
-      "centos-6.4": "ami-a665c0bb",
+      "centos-6.5": "ami-7d02a260",
       "fedora-20": "ami-2345e73e",
       "debian-7.6": "ami-f7d079ea"
     },
@@ -62,7 +62,7 @@
       "ubuntu-13.04": "ami-a73371ce",
       "ubuntu-13.10": "ami-a65393ce",
       "ubuntu-14.04": "ami-4a915c22",
-      "centos-6.4": "ami-bf5021d6",
+      "centos-6.5": "ami-8997afe0",
       "fedora-20": "ami-21362b48",
       "debian-7.6": "ami-f4ad649c"
     },
@@ -73,7 +73,7 @@
       "ubuntu-13.04": "ami-fe052fbb",
       "ubuntu-13.10": "ami-bb2a2afe",
       "ubuntu-14.04": "ami-d99a9a9c",
-      "centos-6.4": "ami-5d456c18",
+      "centos-6.5": "ami-1a013c5f",
       "fedora-20": "ami-f8f1c8bd",
       "debian-7.6": "ami-89dd0cfe"
     },
@@ -84,7 +84,7 @@
       "ubuntu-13.04": "ami-4ade427a",
       "ubuntu-13.10": "ami-c18ff1f1",
       "ubuntu-14.04": "ami-b7720b87",
-      "centos-6.4": "ami-b3bf2f83",
+      "centos-6.5": "ami-b6bdde86",
       "fedora-20": "ami-cc8de6fc",
       "debian-7.6": "ami-476c1477"
     }


### PR DESCRIPTION
This adds a Fedora 20 AMI and updates the CentOS and Debian AMIs.