### PR TITLE
Add support for IAM credentials

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -32,7 +32,7 @@ module Kitchen
 
       include Fog::AWS::CredentialFetcher::ServiceMethods
 
-      iam_credentials = fetch_credentials(use_iam_profile: true) rescue {}
+      iam_creds = fetch_credentials(use_iam_profile: true) rescue {}
 
       default_config :region,             'us-east-1'
       default_config :availability_zone,  'us-east-1b'
@@ -43,13 +43,13 @@ module Kitchen
       default_config :iam_profile_name,   nil
       default_config :price,   nil
       default_config :aws_access_key_id do |driver|
-        iam_credentials[:aws_access_key_id] || ENV['AWS_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY_ID']
+        iam_creds[:aws_access_key_id] || ENV['AWS_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY_ID']
       end
       default_config :aws_secret_access_key do |driver|
-        iam_credentials[:aws_secret_access_key] || ENV['AWS_SECRET_KEY'] || ENV['AWS_SECRET_ACCESS_KEY']
+        iam_creds[:aws_secret_access_key] || ENV['AWS_SECRET_KEY'] || ENV['AWS_SECRET_ACCESS_KEY']
       end
       default_config :aws_session_token do |driver|
-        iam_credentials[:aws_session_token] || ENV['AWS_SESSION_TOKEN'] || ENV['AWS_TOKEN']
+        iam_creds[:aws_session_token] || ENV['AWS_SESSION_TOKEN'] || ENV['AWS_TOKEN']
       end
       default_config :aws_ssh_key_id do |driver|
         ENV['AWS_SSH_KEY_ID']
@@ -80,10 +80,10 @@ module Kitchen
         return if state[:server_id]
 
         info("Creating <#{state[:server_id]}>...")
-        info("If you are not using an account that qualifies under the AWS")
-        info("free-tier, you may be charged to run these suites. The charge")
-        info("should be minimal, but neither Test Kitchen nor its maintainers")
-        info("are responsible for your incurred costs.")
+        info('If you are not using an account that qualifies under the AWS')
+        info('free-tier, you may be charged to run these suites. The charge')
+        info('should be minimal, but neither Test Kitchen nor its maintainers')
+        info('are responsible for your incurred costs.')
 
         if config[:price]
           # Spot instance when a price is set

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -30,6 +30,10 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Ec2 < Kitchen::Driver::SSHBase
 
+      include Fog::AWS::CredentialFetcher::ServiceMethods
+
+      iam_credentials = fetch_credentials(use_iam_profile: true) rescue {}
+
       default_config :region,             'us-east-1'
       default_config :availability_zone,  'us-east-1b'
       default_config :flavor_id,          'm1.small'
@@ -39,13 +43,13 @@ module Kitchen
       default_config :iam_profile_name,   nil
       default_config :price,   nil
       default_config :aws_access_key_id do |driver|
-        ENV['AWS_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY_ID']
+        iam_credentials[:aws_access_key_id] || ENV['AWS_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY_ID']
       end
       default_config :aws_secret_access_key do |driver|
-        ENV['AWS_SECRET_KEY'] || ENV['AWS_SECRET_ACCESS_KEY']
+        iam_credentials[:aws_secret_access_key] || ENV['AWS_SECRET_KEY'] || ENV['AWS_SECRET_ACCESS_KEY']
       end
       default_config :aws_session_token do |driver|
-        ENV['AWS_SESSION_TOKEN'] || ENV['AWS_TOKEN']
+        iam_credentials[:aws_session_token] || ENV['AWS_SESSION_TOKEN'] || ENV['AWS_TOKEN']
       end
       default_config :aws_ssh_key_id do |driver|
         ENV['AWS_SSH_KEY_ID']


### PR DESCRIPTION
As mentioned in https://github.com/test-kitchen/kitchen-ec2/issues/55.

This change will add support for using IAM temporary credentials when creating EC2 instances. Currently the credentials will have to be set in the environment, while an EC2 instance that's set up with an IAM profile can fetch its temporary credentials from the metadata server.