### PR TITLE
aws_ssh_key_id - AWS CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ or `nil` otherwise.
 The default will be read from the `AWS_SSH_KEY_ID` environment variable if set,
 or `nil` otherwise.
 
+This must be one of the KeyName values shown by the AWS CLI: `aws ec2 describe-key-pairs`
+
 ### <a name="config-aws-session-token"></a> aws\_session\_token
 
 The AWS [session token][credentials_docs] to use.


### PR DESCRIPTION
aws_ssh_key_id possible values can be found using AWS CLI