### PR TITLE
Create /etc/chef/ohai/hints/ec2.json

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -103,6 +103,10 @@ module Kitchen
           :ssh_timeout => config[:ssh_timeout],
           :ssh_retries => config[:ssh_retries]
         })
+        # create hints file
+        Kitchen::SSH.new(*build_ssh_args(state)) do |conn|
+          run_remote("mkdir -p /etc/chef/ohai/hints; touch /etc/chef/ohai/hints/ec2.json", conn)
+        end
         print "(ssh ready)\n"
         debug("ec2:create '#{state[:hostname]}'")
       rescue Fog::Errors::Error, Excon::Errors::Error => ex


### PR DESCRIPTION
This should create `/etc/chef/ohai/hints/ec2.json` during create stage as stated in #86. I'm new to Ruby and I couldn't test it properly, so please double check before merging. It would also be good and relatively easy to create a test case for ths but I'm complete noob, I have no idea so far how to do it.