### PR TITLE
Fix security_group_ids parameter for spot requests

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -177,7 +177,7 @@ module Kitchen
 
         connection.spot_requests.create(
           :availability_zone         => config[:availability_zone],
-          :security_group_ids        => config[:security_group_ids],
+          :groups                    => config[:security_group_ids],
           :tags                      => config[:tags],
           :flavor_id                 => config[:flavor_id],
           :ebs_optimized             => config[:ebs_optimized],


### PR DESCRIPTION
The parameter used by Fog to create a spot request is actually `:groups`. This fixes the parameter so that specifying security groups when requesting spot instances with the `price` option works.