### PR TITLE
New `block_device_mappings` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,45 @@ or `nil` otherwise.
 
 ### <a name="config-ebs_volume_size"></a> ebs\_volume\_size
 
-**Required** Size of ebs volume in GB.
+**Deprecated** See [block_device_mappings](#config-block_device_mappings) below.
+
+Size of ebs volume in GB.
 
 ### <a name="config-ebs_delete_on_termination"></a> ebs\_delete\_on\_termination
 
-**Required** `true` if you want ebs volumes to get deleted automatically after instance is terminated, `false` otherwise
+**Deprecated** See [block_device_mappings](#config-block_device_mappings) below.
+
+`true` if you want ebs volumes to get deleted automatically after instance is terminated, `false` otherwise
 
 ### <a name="config-ebs_device_name"></a> ebs\_device\_name
 
-**Required** name of your ebs device, for example: `/dev/sda1`
+**Deprecated** See [block_device_mappings](#config-block_device_mappings) below.
+
+name of your ebs device, for example: `/dev/sda1`
+
+### <a name="config-block_device_mappings"></a> block\_device\_mappings
+
+**Required** A list of block device mappings for the machine.  An example of all available keys looks like:
+```yaml
+block_device_mappings:
+  - ebs_device_name: /dev/sda1
+    ebs_volume_size: 20
+    ebs_delete_on_termination: true
+  - ebs_device_name: /dev/sda1
+    ebs_volume_type: gp2
+    ebs_virtual_name: test
+    ebs_volume_size: 15
+    ebs_delete_on_termination: true
+    ebs_snapshot_id: snap-0015d0bc
+```
+
+The keys `ebs_device_name`, `ebs_volume_size` and `ebs_delete_on_termination` are required for every mapping.
+For backwards compatiability a default `block_device_mappings` will be created if none are listed and the deprecated
+storage config keys are present.
+
+The keys `ebs_volume_type`, `ebs_virtual_name` and `ebs_snapshot_id` are optional.  See
+[Amazon EBS Volume Types](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) to find out more about
+volume types. `ebs_volume_type` defaults to `standard` but can also be `gp2` or `io1`.
 
 ### endpoint
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require "bundler/gem_tasks"
 require 'cane/rake_task'
 require 'tailor/rake_task'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:test)
 
 desc "Run cane to check quality metrics"
 Cane::RakeTask.new do |cane|
@@ -16,6 +19,6 @@ task :stats do
 end
 
 desc "Run all quality tasks"
-task :quality => [:cane, :tailor, :stats]
+task :quality => [:cane, :tailor, :stats, :test]
 
 task :default => [:quality]

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -300,6 +300,7 @@ module Kitchen
           :ebs_volume_size => 'Ebs.VolumeSize',
           :ebs_volume_type => 'Ebs.VolumeType',
           :ebs_delete_on_termination => 'Ebs.DeleteOnTermination',
+          :ebs_snapshot_id => 'Ebs.SnapshotId',
           :ebs_device_name => 'DeviceName',
           :ebs_virtual_name => 'VirtualName'
       }
@@ -313,12 +314,20 @@ module Kitchen
             :ebs_volume_type => 'standard',
             :ebs_volume_size => config[:ebs_volume_size],
             :ebs_delete_on_termination => config[:ebs_delete_on_termination],
+            :ebs_snapshot_id => nil,
             :ebs_device_name => config[:ebs_device_name],
             :ebs_virtual_name => nil
           }]
         end
 
-        # Lets validate that all the provided mappings have required fields
+        # This could be helpful for users debugging
+        image = connection.images.get(config[:image_id])
+        root_device_name = image.root_device_name
+        bdms.find {|bdm|
+          if bdm[:ebs_device_name] == root_device_name
+            info("Overriding root device [#{root_device_name}] from image [#{config[:image_id]}]")
+          end
+        }
 
         # Convert the provided keys to what Fog expects
         bdms = bdms.map do |bdm|

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -78,7 +78,8 @@ module Kitchen
       deprecated_configs.each do |d|
         validations[d] = lambda do |attr, val, driver|
           unless val.nil?
-            warn("WARN: The config key `#{attr}` is deprecated, please use `block_device_mappings`")
+            driver.warn "WARN: The config key `#{attr}` is deprecated," +
+              " please use `block_device_mappings`"
           end
         end
       end
@@ -265,7 +266,7 @@ module Kitchen
       #
       def self.hostname(server, interface_type=nil)
         if interface_type
-          INTERFACE_TYPES.fetch(interface_type) do
+          interface_type = INTERFACE_TYPES.fetch(interface_type) do
             raise Kitchen::UserError, "Invalid interface [#{interface_type}]"
           end
           server.send(interface_type)
@@ -321,11 +322,15 @@ module Kitchen
         end
 
         # This could be helpful for users debugging
-        image = connection.images.get(config[:image_id])
+        image_id = config[:image_id]
+        image = connection.images.get(image_id)
+        if image.nil?
+          raise "Could not find image [#{image_id}]"
+        end
         root_device_name = image.root_device_name
         bdms.find { |bdm|
           if bdm[:ebs_device_name] == root_device_name
-            info("Overriding root device [#{root_device_name}] from image [#{config[:image_id]}]")
+            info("Overriding root device [#{root_device_name}] from image [#{image_id}]")
           end
         }
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -78,7 +78,7 @@ module Kitchen
       deprecated_configs.each do |d|
         validations[d] = lambda do |attr, val, driver|
           unless val.nil?
-            warn("WARN: The config key `#{attr}` is deprecated - please use `block_device_mappings`")
+            warn("WARN: The config key `#{attr}` is deprecated, please use `block_device_mappings`")
           end
         end
       end
@@ -87,10 +87,10 @@ module Kitchen
       validations[:block_device_mappings] = lambda do |attr, val, driver|
         val.each do |bdm|
           unless bdm.keys.include?(:ebs_volume_size) &&
-              bdm.keys.include?(:ebs_delete_on_termination) &&
-              bdm.keys.include?(:ebs_device_name)
+            bdm.keys.include?(:ebs_delete_on_termination) &&
+            bdm.keys.include?(:ebs_device_name)
             raise "Every :block_device_mapping must include the keys :ebs_volume_size, " +
-                    ":ebs_delete_on_termination and :ebs_device_name"
+              ":ebs_delete_on_termination and :ebs_device_name"
           end
         end
       end
@@ -297,12 +297,12 @@ module Kitchen
 
       # A mapping from config key values to what Fog expects
       CONFIG_TO_AWS = {
-          :ebs_volume_size => 'Ebs.VolumeSize',
-          :ebs_volume_type => 'Ebs.VolumeType',
-          :ebs_delete_on_termination => 'Ebs.DeleteOnTermination',
-          :ebs_snapshot_id => 'Ebs.SnapshotId',
-          :ebs_device_name => 'DeviceName',
-          :ebs_virtual_name => 'VirtualName'
+        :ebs_volume_size => 'Ebs.VolumeSize',
+        :ebs_volume_type => 'Ebs.VolumeType',
+        :ebs_delete_on_termination => 'Ebs.DeleteOnTermination',
+        :ebs_snapshot_id => 'Ebs.SnapshotId',
+        :ebs_device_name => 'DeviceName',
+        :ebs_virtual_name => 'VirtualName'
       }
 
       def block_device_mappings
@@ -323,7 +323,7 @@ module Kitchen
         # This could be helpful for users debugging
         image = connection.images.get(config[:image_id])
         root_device_name = image.root_device_name
-        bdms.find {|bdm|
+        bdms.find { |bdm|
           if bdm[:ebs_device_name] == root_device_name
             info("Overriding root device [#{root_device_name}] from image [#{config[:image_id]}]")
           end

--- a/spec/create_spec.rb
+++ b/spec/create_spec.rb
@@ -17,20 +17,24 @@ describe Kitchen::Driver::Ec2 do
     end
 
     let(:server) do
-      double(:id => "123",
-             :wait_for => nil,
-             :dns_name => "server.example.com",
-             :private_ip_address => '172.13.16.11',
-             :public_ip_address => '213.225.123.134')
+      double(
+       :id => "123",
+       :wait_for => nil,
+       :dns_name => "server.example.com",
+       :private_ip_address => '172.13.16.11',
+       :public_ip_address => '213.225.123.134'
+      )
     end
 
     let(:instance) do
-      Kitchen::Instance.new(:platform => double(:name => "centos-6.4"),
-                            :suite => double(:name => "default"),
-                            :driver => driver,
-                            :provisioner => Kitchen::Provisioner::Dummy.new({}),
-                            :busser => double("busser"),
-                            :state_file => double("state_file"))
+      Kitchen::Instance.new(
+        :platform => double(:name => "centos-6.4"),
+        :suite => double(:name => "default"),
+        :driver => driver,
+        :provisioner => Kitchen::Provisioner::Dummy.new({}),
+        :busser => double("busser"),
+        :state_file => double("state_file")
+      )
     end
 
     let(:driver) do
@@ -65,7 +69,7 @@ describe Kitchen::Driver::Ec2 do
 
     it 'throws a nice exception if the config is bogus' do
       config[:interface] = 'I am an idiot'
-      expect { driver.create(state) }.to raise_error(Kitchen::UserError, 'Invalid interface')
+      expect { driver.create(state) }.to raise_error(Kitchen::UserError, /^Invalid interface/)
     end
 
   end
@@ -122,6 +126,112 @@ describe Kitchen::Driver::Ec2 do
       expect(config[:user_data]).to eql("#!/bin/bash\necho server > /tmp/hostname")
     end
 
+  end
+
+  describe '#block_device_mappings' do
+    let(:connection) { double(Fog::Compute) }
+    let(:image) { double('Image', :root_device_name => 'name') }
+    before do
+      expect(driver).to receive(:connection).and_return(connection)
+    end
+
+    context 'with bad config[:image_id]' do
+      let(:config) do
+        {
+          aws_ssh_key_id: 'larry',
+          aws_access_key_id: 'secret',
+          aws_secret_access_key: 'moarsecret',
+          image_id: 'foobar'
+        }
+      end
+
+      it 'raises an error' do
+        expect(connection).to receive_message_chain('images.get').with('foobar').and_return nil
+        expect { driver.send(:block_device_mappings) }.to raise_error(/Could not find image/)
+      end
+    end
+
+    context 'with good config[:image_id]' do
+      before do
+        expect(connection).to receive_message_chain('images.get')
+          .with('ami-bf5021d6').and_return image
+      end
+
+      context 'no config is set' do
+        it 'returns an empty default' do
+          expect(driver.send(:block_device_mappings)).to eq([{
+            "Ebs.VolumeType"=>"standard",
+            "Ebs.VolumeSize"=>nil,
+            "Ebs.DeleteOnTermination"=>nil,
+            "Ebs.SnapshotId"=>nil,
+            "DeviceName"=>nil,
+            "VirtualName"=>nil
+          }])
+        end
+      end
+
+      context 'deprecated configs are set' do
+        let(:config) do
+          {
+              aws_ssh_key_id: 'larry',
+              aws_access_key_id: 'secret',
+              aws_secret_access_key: 'moarsecret',
+              ebs_volume_size: 100,
+              ebs_delete_on_termination: false,
+              ebs_device_name: 'name'
+          }
+        end
+
+        it 'returns an empty default' do
+          expect(driver.send(:block_device_mappings)).to eq([{
+            "Ebs.VolumeType"=>"standard",
+            "Ebs.VolumeSize"=>100,
+            "Ebs.DeleteOnTermination"=>false,
+            "Ebs.SnapshotId"=>nil,
+            "DeviceName"=>'name',
+            "VirtualName"=>nil
+          }])
+        end
+      end
+
+      context 'deprecated configs are set and so are new configs' do
+        let(:block1) do
+          {
+            :ebs_volume_type => 'io1',
+            :ebs_volume_size => 22,
+            :ebs_delete_on_termination => true,
+            :ebs_snapshot_id => 'snap-12345',
+            :ebs_device_name => '/dev/sda1',
+            :ebs_virtual_name => 'main'
+          }
+        end
+
+        let(:config) do
+          {
+            aws_ssh_key_id: 'larry',
+            aws_access_key_id: 'secret',
+            aws_secret_access_key: 'moarsecret',
+            ebs_volume_size: 100,
+            ebs_delete_on_termination: false,
+            ebs_device_name: 'name',
+            block_device_mappings: [
+              block1
+            ]
+          }
+        end
+
+        it 'returns the new configs' do
+          expect(driver.send(:block_device_mappings)).to eq([{
+            "Ebs.VolumeType"=>'io1',
+            "Ebs.VolumeSize"=>22,
+            "Ebs.DeleteOnTermination"=>true,
+            "Ebs.SnapshotId"=>'snap-12345',
+            "DeviceName"=>'/dev/sda1',
+            "VirtualName"=>'main'
+          }])
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
This PR rolls a bunch of existing, storage based PRs into one:

* Closes https://github.com/test-kitchen/kitchen-ec2/issues/71
* Connects to https://github.com/test-kitchen/kitchen-ec2/pull/64
* Connects to https://github.com/test-kitchen/kitchen-ec2/pull/43
* Connects to https://github.com/test-kitchen/kitchen-ec2/pull/78
* Connects to https://github.com/test-kitchen/kitchen-ec2/pull/76

I am deprecating the old, individual storage config keys and adding a new one which accepts a list.  This allows users to specify multiple block device mappings.  If one of the entries has the same name as the image root storage device it will be overridden.

To support backwards compatiability if you do not use the new `block_device_mappings` config it will be auto created using the old deprecated configs.  It emits a warning because we will eventually remove this functionality.

How are the READMEs?  What do you think about usability?

\cc @fnichol @rvalyi @victorlin @nsdavidson @duggan