### PR TITLE
Fix the regression after changes in 23f4d945

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -247,7 +247,7 @@ module Kitchen
       #
       def self.hostname(server, interface_type=nil)
         if interface_type
-          INTERFACE_TYPES.fetch(interface_type) do
+          interface_type = INTERFACE_TYPES.fetch(interface_type) do
             raise Kitchen::UserError, "Invalid interface [#{interface_type}]"
           end
           server.send(interface_type)


### PR DESCRIPTION
Hi,

Thanks for developing the great software :)

I have a fix for the regression in kitchen-ec2 on the master branch, which has occured after 23f4d945 (more specifically, [the change in this line](https://github.com/test-kitchen/kitchen-ec2/commit/23f4d9450b9080b686058b44d23f8be368dcf2c7#diff-c5498dad76244656522b77033980c6a6R238)).

The regression is causing every `kitchen test` run eventually fails while trying to connect the newly created EC2 instance when you provided a value for the `interface` configuration parameter.

For instance, when you provided the value `public` for `interface`, `kitchen test` fails with the failure message:

```
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #create action: [undefined method `public' for #<Fog::Compute::AWS::Server:0x000000041bc430>]
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```
