### PR TITLE
Adding now required block_device_mappings config to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,10 @@ driver:
   iam_profile_name: chef-client
   ssh_timeout: 10
   ssh_retries: 5
-  ebs_volume_size: 6,
-  ebs_delete_on_termination: true
-  ebs_device_name: '/dev/sda1'
+  block_device_mappings:
+    - ebs_device_name: /dev/sda1
+      ebs_volume_size: 20
+      ebs_delete_on_termination: true
   flavor_id: t2.micro
 
 platforms:
@@ -323,6 +324,10 @@ driver:
   region: us-east-1
   availability_zone: us-east-1b
   require_chef_omnibus: true
+  block_device_mappings:
+    - ebs_device_name: /dev/sda1
+      ebs_volume_size: 20
+      ebs_delete_on_termination: true
 
 platforms:
   - name: ubuntu-12.04


### PR DESCRIPTION
The block_device_mappings is now required in the configuration. I added the block_device_mappings to the example that did not work as such due of this missing block_device_mappings configuration.