### PR TITLE
Add explicit option for using iam profile for authentication

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -49,8 +49,7 @@ module Kitchen
           driver.iam_creds[:aws_secret_access_key]
       end
       default_config :aws_session_token do |driver|
-        ENV['AWS_SESSION_TOKEN'] || ENV['AWS_TOKEN'] ||
-          driver.iam_creds[:aws_session_token]
+        driver.default_aws_session_token
       end
       default_config :aws_ssh_key_id do |driver|
         ENV['AWS_SSH_KEY_ID']
@@ -175,6 +174,16 @@ module Kitchen
 
       def default_public_ip_association
         !!config[:subnet_id]
+      end
+
+      def default_aws_session_token
+        env = ENV['AWS_SESSION_TOKEN'] || ENV['AWS_TOKEN']
+        if config[:aws_secret_access_key] == iam_creds[:aws_secret_access_key] \
+          && config[:aws_access_key_id] == iam_creds[:aws_access_key_id]
+          env || iam_creds[:aws_session_token]
+        else
+          env
+        end
       end
 
       private

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -29,7 +29,7 @@ module Kitchen
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Ec2 < Kitchen::Driver::SSHBase
-      extend Fog::AWS::CredentialFetcher::ServiceMethods
+      include Fog::AWS::CredentialFetcher::ServiceMethods
       default_config :region,             'us-east-1'
       default_config :availability_zone,  'us-east-1b'
       default_config :flavor_id,          'm1.small'

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -44,8 +44,8 @@ module Kitchen
         ENV['AWS_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY_ID'] || driver.iam_creds[:aws_access_key_id]
       end
       default_config :aws_secret_access_key do |driver|
-        ENV['AWS_SECRET_KEY'] || ENV['AWS_SECRET_ACCESS_KEY'] \
-          || driver.iam_creds[:aws_secret_access_key]
+        ENV['AWS_SECRET_KEY'] || ENV['AWS_SECRET_ACCESS_KEY'] ||
+          driver.iam_creds[:aws_secret_access_key]
       end
       default_config :aws_session_token do |driver|
         driver.default_aws_session_token

--- a/spec/create_spec.rb
+++ b/spec/create_spec.rb
@@ -138,28 +138,44 @@ describe Kitchen::Driver::Ec2 do
 
   context 'When #iam_creds returns values' do
     context 'but they should not be used' do
-      context 'because :aws_access_key_id is not set via iam_creds' do
-        it 'does not set config[:aws_session_token]' do
-          config[:aws_access_key_id] = 'adifferentkey'
-          allow(driver).to receive(:iam_creds).and_return(iam_creds)
+      let(:config) do
+        {
+          aws_ssh_key_id: 'larry',
+          user_data: nil
+        }
+      end
+
+      before do
+        allow(ENV).to receive(:[]).and_return(nil)
+        allow(driver).to receive(:iam_creds).and_return(iam_creds)
+      end
+
+      context 'because :aws_access_key_id is explicitly set' do
+        before { config[:aws_access_key_id] = 'adifferentkey' }
+        it 'does not override :aws_access_key_id' do
+          expect(driver.send(:config)[:aws_access_key_id]).to eq('adifferentkey')
+        end
+
+        it 'does not set :aws_session_token' do
           expect(driver.send(:config)[:aws_session_token]).to be_nil
         end
       end
 
-      context 'because :aws_secret_key_id is not set via iam_creds' do
-        it 'does not set config[:aws_session_token]' do
-          config[:aws_secret_access_key] = 'adifferentsecret'
-          allow(driver).to receive(:iam_creds).and_return(iam_creds)
+      context 'because :aws_access_key_id is explicitly set' do
+        before { config[:aws_secret_access_key] = 'adifferentsecret' }
+        it 'does not override :aws_secret_access_key' do
+          expect(driver.send(:config)[:aws_secret_access_key]).to eq('adifferentsecret')
+        end
+
+        it 'does not set :aws_session_token' do
           expect(driver.send(:config)[:aws_session_token]).to be_nil
         end
       end
 
-      context 'because :aws_secret_key_id and :aws_access_key_id are set via iam_creds' do
-        it 'does not set config[:aws_session_token]' do
-          config[:aws_access_key_id] = 'adifferentkey'
-          config[:aws_secret_access_key] = 'adifferentsecret'
-          allow(driver).to receive(:iam_creds).and_return(iam_creds)
-          expect(driver.send(:config)[:aws_session_token]).to be_nil
+      context 'because :aws_session_token is explicitly set' do
+        before { config[:aws_session_token] = 'adifferentsessiontoken' }
+        it 'does not override :aws_session_token' do
+          expect(driver.send(:config)[:aws_session_token]).to eq('adifferentsessiontoken')
         end
       end
     end

--- a/spec/create_spec.rb
+++ b/spec/create_spec.rb
@@ -176,7 +176,7 @@ describe Kitchen::Driver::Ec2 do
 
       context 'when #fetch_credentials fails with StandardError' do
         it 'returns an empty hash' do
-          allow(driver).to receive(:fetch_credentials).and_raise(StandardError)
+          allow(driver).to receive(:fetch_credentials).and_raise(::StandardError)
           expect(driver.iam_creds).to eq({})
         end
       end

--- a/spec/create_spec.rb
+++ b/spec/create_spec.rb
@@ -148,56 +148,37 @@ describe Kitchen::Driver::Ec2 do
       before do
         allow(ENV).to receive(:[]).and_return(nil)
         allow(driver).to receive(:iam_creds).and_return(iam_creds)
+        allow(Net::HTTP).to receive(:get).with(URI.parse('http://169.254.169.254')).and_return(true)
       end
 
-      context 'because :aws_access_key_id is explicitly set' do
+      context 'because :aws_access_key_id is set but not via #iam_creds' do
         before { config[:aws_access_key_id] = 'adifferentkey' }
         it 'does not override :aws_access_key_id' do
           expect(driver.send(:config)[:aws_access_key_id]).to eq('adifferentkey')
         end
 
-        it 'does not set :aws_secret_access_key via #iam_creds' do
-          expect(driver.send(:config)[:aws_secret_access_key])
-            .to_not eq(iam_creds[:aws_secret_access_key])
-        end
-
         it 'does not set :aws_session_token via #iam_creds' do
           expect(driver.send(:config)[:aws_session_token])
             .to_not eq(iam_creds[:aws_session_token])
         end
       end
 
-      context 'because :aws_access_key_id is explicitly set' do
+      context 'because :aws_access_key_id is set but not via #iam_creds' do
         before { config[:aws_secret_access_key] = 'adifferentsecret' }
         it 'does not override :aws_secret_access_key' do
           expect(driver.send(:config)[:aws_secret_access_key]).to eq('adifferentsecret')
         end
 
-        it 'does not set :aws_access_key_id via #iam_creds' do
-          expect(driver.send(:config)[:aws_access_key_id])
-            .to_not eq(iam_creds[:aws_access_key_id])
-        end
-
         it 'does not set :aws_session_token via #iam_creds' do
           expect(driver.send(:config)[:aws_session_token])
             .to_not eq(iam_creds[:aws_session_token])
         end
       end
 
-      context 'because :aws_session_token is explicitly set' do
+      context 'because :aws_session_token is set but not via #iam_creds' do
         before { config[:aws_session_token] = 'adifferentsessiontoken' }
         it 'does not override :aws_session_token' do
           expect(driver.send(:config)[:aws_session_token]).to eq('adifferentsessiontoken')
-        end
-
-        it 'does not set :aws_access_key_id via #iam_creds' do
-          expect(driver.send(:config)[:aws_access_key_id])
-            .to_not eq(iam_creds[:aws_access_key_id])
-        end
-
-        it 'does not set :aws_secret_access_key via #iam_creds' do
-          expect(driver.send(:config)[:aws_secret_access_key])
-            .to_not eq(iam_creds[:aws_secret_access_key])
         end
       end
     end
@@ -249,7 +230,7 @@ describe Kitchen::Driver::Ec2 do
         end
       end
 
-      context 'when #fetch_credentials fails with StandardError' do
+      context 'when #fetch_credentials fails with ::StandardError' do
         it 'returns an empty hash' do
           allow(driver).to receive(:fetch_credentials).and_raise(::StandardError)
           expect(driver.iam_creds).to eq({})

--- a/spec/create_spec.rb
+++ b/spec/create_spec.rb
@@ -160,14 +160,6 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context 'when :aws_secret_key_id and :aws_access_key_id are set via iam_creds' do
-      let(:credentials) do
-        {
-          aws_access_key_id: 'secret',
-          aws_secret_access_key: 'moarsecret',
-          aws_session_token: 'randomsecret'
-        }
-      end
-
       it 'uses :aws_session_token from iam_creds' do
         allow(driver)
           .to receive(:iam_creds).and_return(iam_creds)

--- a/spec/create_spec.rb
+++ b/spec/create_spec.rb
@@ -156,8 +156,14 @@ describe Kitchen::Driver::Ec2 do
           expect(driver.send(:config)[:aws_access_key_id]).to eq('adifferentkey')
         end
 
-        it 'does not set :aws_session_token' do
-          expect(driver.send(:config)[:aws_session_token]).to be_nil
+        it 'does not set :aws_secret_access_key via #iam_creds' do
+          expect(driver.send(:config)[:aws_secret_access_key])
+            .to_not eq(iam_creds[:aws_secret_access_key])
+        end
+
+        it 'does not set :aws_session_token via #iam_creds' do
+          expect(driver.send(:config)[:aws_session_token])
+            .to_not eq(iam_creds[:aws_session_token])
         end
       end
 
@@ -167,8 +173,14 @@ describe Kitchen::Driver::Ec2 do
           expect(driver.send(:config)[:aws_secret_access_key]).to eq('adifferentsecret')
         end
 
-        it 'does not set :aws_session_token' do
-          expect(driver.send(:config)[:aws_session_token]).to be_nil
+        it 'does not set :aws_access_key_id via #iam_creds' do
+          expect(driver.send(:config)[:aws_access_key_id])
+            .to_not eq(iam_creds[:aws_access_key_id])
+        end
+
+        it 'does not set :aws_session_token via #iam_creds' do
+          expect(driver.send(:config)[:aws_session_token])
+            .to_not eq(iam_creds[:aws_session_token])
         end
       end
 
@@ -176,6 +188,16 @@ describe Kitchen::Driver::Ec2 do
         before { config[:aws_session_token] = 'adifferentsessiontoken' }
         it 'does not override :aws_session_token' do
           expect(driver.send(:config)[:aws_session_token]).to eq('adifferentsessiontoken')
+        end
+
+        it 'does not set :aws_access_key_id via #iam_creds' do
+          expect(driver.send(:config)[:aws_access_key_id])
+            .to_not eq(iam_creds[:aws_access_key_id])
+        end
+
+        it 'does not set :aws_secret_access_key via #iam_creds' do
+          expect(driver.send(:config)[:aws_secret_access_key])
+            .to_not eq(iam_creds[:aws_secret_access_key])
         end
       end
     end

--- a/spec/create_spec.rb
+++ b/spec/create_spec.rb
@@ -138,13 +138,6 @@ describe Kitchen::Driver::Ec2 do
 
   context 'When #iam_creds returns values' do
     context 'but they should not be used' do
-      let(:config) do
-        {
-          aws_ssh_key_id: 'larry',
-          user_data: nil
-        }
-      end
-
       before do
         allow(ENV).to receive(:[]).and_return(nil)
         allow(driver).to receive(:iam_creds).and_return(iam_creds)
@@ -152,9 +145,8 @@ describe Kitchen::Driver::Ec2 do
       end
 
       context 'because :aws_access_key_id is set but not via #iam_creds' do
-        before { config[:aws_access_key_id] = 'adifferentkey' }
         it 'does not override :aws_access_key_id' do
-          expect(driver.send(:config)[:aws_access_key_id]).to eq('adifferentkey')
+          expect(driver.send(:config)[:aws_access_key_id]).to eq(config[:aws_access_key_id])
         end
 
         it 'does not set :aws_session_token via #iam_creds' do
@@ -164,9 +156,8 @@ describe Kitchen::Driver::Ec2 do
       end
 
       context 'because :aws_access_key_id is set but not via #iam_creds' do
-        before { config[:aws_secret_access_key] = 'adifferentsecret' }
         it 'does not override :aws_secret_access_key' do
-          expect(driver.send(:config)[:aws_secret_access_key]).to eq('adifferentsecret')
+          expect(driver.send(:config)[:aws_secret_access_key]).to eq(config[:aws_secret_access_key])
         end
 
         it 'does not set :aws_session_token via #iam_creds' do

--- a/spec/create_spec.rb
+++ b/spec/create_spec.rb
@@ -128,6 +128,37 @@ describe Kitchen::Driver::Ec2 do
 
   end
 
+  describe '#iam_creds' do
+    context 'when use_iam_profile is not set' do
+      it 'returns an empty hash' do
+        expect(driver.iam_creds).to eq({})
+      end
+    end
+
+    context 'when use_iam_profile is set to true' do
+      let(:credentials) do
+        {
+          aws_access_key_id: 'secret',
+          aws_secret_access_key: 'moarsecret',
+          aws_session_token: 'randomsecret'
+        }
+      end
+
+      it 'calls fetch_credentials' do
+        config[:use_iam_profile] = true
+
+        allow(driver)
+          .to receive(:fetch_credentials).and_return(credentials)
+
+        expect(driver)
+          .to receive(:fetch_credentials)
+          .with(use_iam_profile: true)
+
+        expect(driver.iam_creds).to eq(credentials)
+      end
+    end
+  end
+
   describe '#block_device_mappings' do
     let(:connection) { double(Fog::Compute) }
     let(:image) { double('Image', :root_device_name => 'name') }


### PR DESCRIPTION
PR #104 broke the ability to use kitchen-ec2 with explicit aws credentials set via .kitchen.yml while on an ec2 host.

When on an ec2 host the `#fetch_credentials` method which is included from `Fog::AWS::CredentialFetcher::ServiceMethods` will always return a hash with a value set for the `:aws_session_token` key. Because of this `config[:aws_session_token]` will always default to `iam_creds[:aws_session_token]`. Since `config[:aws_session_token]` is passed to `#connection`, `Fog::Compute` fails to authenticate using any credentials set in .kitchen.yml since the value of `:aws_session_token` is incorrect.

By adding an option to explicitly use a server's iam profile we can allow hosts which live in ec2 to use .kitchen.yml as well as their iam profile for driver configuration.