### PR TITLE
Only warn about missing credential values, or allow bypass

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -61,7 +61,6 @@ module Kitchen
       default_config :username,            nil
       default_config :associate_public_ip, nil
 
-      required_config :aws_ssh_key_id
       required_config :image_id
 
       def self.validation_warn(driver, old_key, new_key)


### PR DESCRIPTION
I'd like to provide instructions for using kitchen-ec2 where this is possible:

```
sudo pip install awscli
aws configure --profile some-name # Follow prompts
export AWS_DEFAULT_PROFILE=some-name
cp .kitchen.travis.yml .kitchen.local.yml # Has some EC2-specific config, but no credentials
kitchen list
```

Right now, this errors out like so:

```
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::UserError
>>>>>> Message: Kitchen::Driver::Ec2<default-ubuntu-1404>#config[:aws_access_key_id] cannot be blank
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

See: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment

Is this easily possible? Thanks!