### PR TITLE
Fixing :subnet_id payload placement if :associate_public_ip is set

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -55,7 +55,7 @@ module Kitchen
           i[:block_device_mappings] = block_device_mappings unless block_device_mappings.empty?
           i[:security_group_ids] = config[:security_group_ids] if config[:security_group_ids]
           i[:user_data] = prepared_user_data if prepared_user_data
-          if config[:iam_instance_profile]
+          if config[:iam_profile_name]
             i[:iam_instance_profile] = { :name => config[:iam_profile_name] }
           end
           if !config.fetch(:associate_public_ip, nil).nil?

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -64,6 +64,11 @@ module Kitchen
                 :device_index => 0,
                 :associate_public_ip_address => config[:associate_public_ip]
               }]
+            # If specifying `:network_interfaces` in the request, you must specify the
+            # subnet_id in the network_interfaces block and not at the top level
+            if config[:subnet_id]
+              i[:network_interfaces][0][:subnet_id] = i.delete(:subnet_id)
+            end
           end
           i
         end

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -58,11 +58,11 @@ module Kitchen
           if config[:iam_instance_profile]
             i[:iam_instance_profile] = { :name => config[:iam_profile_name] }
           end
-          if !config.fetch(:associate_public_ip_address, nil).nil?
+          if !config.fetch(:associate_public_ip, nil).nil?
             i[:network_interfaces] =
               [{
                 :device_index => 0,
-                :associate_public_ip_address => config[:associate_public_ip_address]
+                :associate_public_ip_address => config[:associate_public_ip]
               }]
           end
           i

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -244,6 +244,47 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       end
     end
 
+    context "when subnet_id is provided" do
+      let(:config) do
+        {
+          :subnet_id => "s-456"
+        }
+      end
+
+      it "adds a network_interfaces block" do
+        expect(generator.ec2_instance_data).to eq(
+          :placement => { :availability_zone => nil },
+          :instance_type => nil,
+          :ebs_optimized => nil,
+          :image_id => nil,
+          :key_name => nil,
+          :subnet_id => "s-456",
+          :private_ip_address => nil
+        )
+      end
+    end
+
+    context "when associate_public_ip is provided" do
+      let(:config) do
+        {
+          :associate_public_ip => true
+        }
+      end
+
+      it "adds a network_interfaces block" do
+        expect(generator.ec2_instance_data).to eq(
+          :placement => { :availability_zone => nil },
+          :instance_type => nil,
+          :ebs_optimized => nil,
+          :image_id => nil,
+          :key_name => nil,
+          :subnet_id => nil,
+          :private_ip_address => nil,
+          :network_interfaces => [{ :device_index => 0, :associate_public_ip_address => true }]
+        )
+      end
+    end
+
     context "when provided the maximum config" do
       let(:config) do
         {
@@ -278,7 +319,6 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           :ebs_optimized => true,
           :image_id => "ami-123",
           :key_name => "key",
-          :subnet_id => "s-456",
           :private_ip_address => "0.0.0.0",
           :block_device_mappings => [
             {
@@ -293,7 +333,11 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
             }
           ],
           :iam_instance_profile => { :name => nil },
-          :network_interfaces => [{ :device_index => 0, :associate_public_ip_address => true }],
+          :network_interfaces => [{
+            :device_index => 0,
+            :associate_public_ip_address => true,
+            :subnet_id => "s-456"
+          }],
           :security_group_ids => ["sg-789"],
           :user_data => "foo"
         )

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -307,7 +307,7 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           ],
           :security_group_ids => ["sg-789"],
           :user_data => "foo",
-          :iam_instance_profile => "iam-123",
+          :iam_profile_name => "iam-123",
           :associate_public_ip => true
         }
       end
@@ -332,7 +332,7 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
               :virtual_name => "test"
             }
           ],
-          :iam_instance_profile => { :name => nil },
+          :iam_instance_profile => { :name => "iam-123" },
           :network_interfaces => [{
             :device_index => 0,
             :associate_public_ip_address => true,

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -267,7 +267,7 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           :security_group_ids => ["sg-789"],
           :user_data => "foo",
           :iam_instance_profile => "iam-123",
-          :associate_public_ip_address => true
+          :associate_public_ip => true
         }
       end
 


### PR DESCRIPTION
See http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#run_instances-instance_method

Amazon does not allow you to specify `subnet_id` at the top level of the request body if you specify `network_interfaces`.  This PR updates our request to include `subnet_id` inside of `network_interfaces` if it is available.

It also reverts a regression I introduced where I accidently renamed `associate_public_ip` to `associate_public_ip_address`.

Aaaaaaand another regression where I accidently renamed `iam_profile_name` to `iam_instance_profile`.

Fixes https://github.com/test-kitchen/kitchen-ec2/issues/72

\cc @fnichol @dsavinkov @yoshiwaan @litjoco