### PR TITLE
Fixing 2 regressions in 0.9.1

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 require "kitchen/logging"
+require "base64"
 
 module Kitchen
 
@@ -134,14 +135,15 @@ module Kitchen
 
         def prepared_user_data
           # If user_data is a file reference, lets read it as such
-          unless @user_data
-            if config[:user_data] && File.file?(config[:user_data])
+          return nil if config[:user_data].nil?
+          @user_data ||= begin
+            if File.file?(config[:user_data])
               @user_data = File.read(config[:user_data])
             else
               @user_data = config[:user_data]
             end
+            @user_data = Base64.encode64(@user_data)
           end
-          @user_data
         end
 
       end

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -63,12 +63,20 @@ module Kitchen
             i[:network_interfaces] =
               [{
                 :device_index => 0,
-                :associate_public_ip_address => config[:associate_public_ip]
+                :associate_public_ip_address => config[:associate_public_ip],
+                :delete_on_termination => true
               }]
-            # If specifying `:network_interfaces` in the request, you must specify the
-            # subnet_id in the network_interfaces block and not at the top level
+            # If specifying `:network_interfaces` in the request, you must specify
+            # network specific configs in the network_interfaces block and not at
+            # the top level
             if config[:subnet_id]
               i[:network_interfaces][0][:subnet_id] = i.delete(:subnet_id)
+            end
+            if config[:private_ip_address]
+              i[:network_interfaces][0][:private_ip_address] = i.delete(:private_ip_address)
+            end
+            if config[:security_group_ids]
+              i[:network_interfaces][0][:groups] = i.delete(:security_group_ids)
             end
           end
           i

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -19,6 +19,7 @@
 require "kitchen/driver/aws/instance_generator"
 require "kitchen/driver/aws/client"
 require "tempfile"
+require "base64"
 
 describe Kitchen::Driver::Aws::InstanceGenerator do
 
@@ -70,14 +71,15 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       end
 
       it "reads the file contents" do
-        expect(generator.prepared_user_data).to eq("foo\nbar")
+        expect(Base64.decode64(generator.prepared_user_data)).to eq("foo\nbar")
       end
 
       it "memoizes the file contents" do
-        expect(generator.prepared_user_data).to eq("foo\nbar")
+        decoded = Base64.decode64(generator.prepared_user_data)
+        expect(decoded).to eq("foo\nbar")
         tmp_file.write("other\nvalue")
         tmp_file.rewind
-        expect(generator.prepared_user_data).to eq("foo\nbar")
+        expect(decoded).to eq("foo\nbar")
       end
     end
   end
@@ -339,7 +341,7 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
             :subnet_id => "s-456"
           }],
           :security_group_ids => ["sg-789"],
-          :user_data => "foo"
+          :user_data => Base64.encode64("foo")
         )
       end
     end

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -282,8 +282,91 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           :key_name => nil,
           :subnet_id => nil,
           :private_ip_address => nil,
-          :network_interfaces => [{ :device_index => 0, :associate_public_ip_address => true }]
+          :network_interfaces => [{
+            :device_index => 0,
+            :associate_public_ip_address => true,
+            :delete_on_termination => true
+          }]
         )
+      end
+
+      context "and subnet is provided" do
+        let(:config) do
+          {
+            :associate_public_ip => true,
+            :subnet_id => "s-456"
+          }
+        end
+
+        it "adds a network_interfaces block" do
+          expect(generator.ec2_instance_data).to eq(
+            :placement => { :availability_zone => nil },
+            :instance_type => nil,
+            :ebs_optimized => nil,
+            :image_id => nil,
+            :key_name => nil,
+            :private_ip_address => nil,
+            :network_interfaces => [{
+              :device_index => 0,
+              :associate_public_ip_address => true,
+              :delete_on_termination => true,
+              :subnet_id => "s-456"
+            }]
+          )
+        end
+      end
+
+      context "and security_group_ids is provided" do
+        let(:config) do
+          {
+            :associate_public_ip => true,
+            :security_group_ids => ["sg-789"]
+          }
+        end
+
+        it "adds a network_interfaces block" do
+          expect(generator.ec2_instance_data).to eq(
+            :placement => { :availability_zone => nil },
+            :instance_type => nil,
+            :ebs_optimized => nil,
+            :image_id => nil,
+            :key_name => nil,
+            :subnet_id => nil,
+            :private_ip_address => nil,
+            :network_interfaces => [{
+              :device_index => 0,
+              :associate_public_ip_address => true,
+              :delete_on_termination => true,
+              :groups => ["sg-789"]
+            }]
+          )
+        end
+      end
+
+      context "and private_ip_address is provided" do
+        let(:config) do
+          {
+            :associate_public_ip => true,
+            :private_ip_address => "0.0.0.0"
+          }
+        end
+
+        it "adds a network_interfaces block" do
+          expect(generator.ec2_instance_data).to eq(
+            :placement => { :availability_zone => nil },
+            :instance_type => nil,
+            :ebs_optimized => nil,
+            :image_id => nil,
+            :key_name => nil,
+            :subnet_id => nil,
+            :network_interfaces => [{
+              :device_index => 0,
+              :associate_public_ip_address => true,
+              :delete_on_termination => true,
+              :private_ip_address => "0.0.0.0"
+            }]
+          )
+        end
       end
     end
 
@@ -321,7 +404,6 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           :ebs_optimized => true,
           :image_id => "ami-123",
           :key_name => "key",
-          :private_ip_address => "0.0.0.0",
           :block_device_mappings => [
             {
               :ebs => {
@@ -338,9 +420,11 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           :network_interfaces => [{
             :device_index => 0,
             :associate_public_ip_address => true,
-            :subnet_id => "s-456"
+            :subnet_id => "s-456",
+            :delete_on_termination => true,
+            :groups => ["sg-789"],
+            :private_ip_address =>  "0.0.0.0"
           }],
-          :security_group_ids => ["sg-789"],
           :user_data => Base64.encode64("foo")
         )
       end


### PR DESCRIPTION
Fixes #121 
Fixes #127 

Also setting the network interface to `delete_on_termination` of the instance so there aren't orphan devices hanging around

\cc @fnichol @kplimack @litjoco