### PR TITLE
Adding proxy support that was present in Fog back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.9.2 / 2015-05-26
+
+### Bug Fixes
+
+* Pull Request [#131][]: Adding back support for a proxy via config `http_proxy` which defaults to `ENV['HTTP_PROXY']`
+* Pull Request [#128][]: 
+    * Fixes [#121][]: Fixing error `Network interfaces and an instance-level security groups may not be specified on the same request` 
+    * Fixes [#127][]: User Data content should be base64 encoded when passed to aws sdk 
+
+### New Features
+
+### Improvements
+
 ## 0.9.1 / 2015-05-21
 
 ### Bug Fixes
@@ -124,8 +137,12 @@
 [#107]: https://github.com/test-kitchen/kitchen-ec2/issues/107
 [#110]: https://github.com/test-kitchen/kitchen-ec2/issues/110
 [#112]: https://github.com/test-kitchen/kitchen-ec2/issues/112
+[#121]: https://github.com/test-kitchen/kitchen-ec2/issues/121
 [#124]: https://github.com/test-kitchen/kitchen-ec2/issues/124
 [#125]: https://github.com/test-kitchen/kitchen-ec2/issues/125
+[#127]: https://github.com/test-kitchen/kitchen-ec2/issues/127
+[#128]: https://github.com/test-kitchen/kitchen-ec2/issues/128
+[#131]: https://github.com/test-kitchen/kitchen-ec2/issues/131
 [@Atalanta]: https://github.com/Atalanta
 [@Igorshp]: https://github.com/Igorshp
 [@JamesAwesome]: https://github.com/JamesAwesome

--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ The price you bid in order to submit a spot request. An additional step will be 
 
 The default is `nil`.
 
+### http\_proxy
+
+Specify a proxy to send AWS requests through.  Should be of the format `http://<host>:<port>`.
+
+The default is `ENV['HTTP_PROXY']`
+
+**Note** - The AWS command line utility allow you to specify [two proxies](http://docs.aws.amazon.com/cli/latest/userguide/cli-http-proxy.html), one for HTTP and one for HTTPS.  The AWS Ruby SDK only allows you to specify 1 proxy and because all requests are `https://` this proxy needs to support HTTPS.
+
 ## Disk Configuration
 
 ### ebs\_volume\_size

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -32,19 +32,21 @@ module Kitchen
       # @author Tyler Ball <tball@chef.io>
       class Client
 
-        def initialize(
+        def initialize( # rubocop:disable Metrics/ParameterLists
           region,
           profile_name = nil,
           access_key_id = nil,
           secret_access_key = nil,
-          session_token = nil
+          session_token = nil,
+          http_proxy = nil
         )
           creds = self.class.get_credentials(
             profile_name, access_key_id, secret_access_key, session_token
           )
           ::Aws.config.update(
             :region => region,
-            :credentials => creds
+            :credentials => creds,
+            :http_proxy => http_proxy
           )
         end
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -62,6 +62,7 @@ module Kitchen
       default_config :username,            nil
       default_config :associate_public_ip, nil
       default_config :interface,           nil
+      default_config :http_proxy,          ENV["HTTPS_PROXY"] || ENV["HTTP_PROXY"]
 
       required_config :aws_ssh_key_id
       required_config :image_id
@@ -250,7 +251,8 @@ module Kitchen
           config[:shared_credentials_profile],
           config[:aws_access_key_id],
           config[:aws_secret_access_key],
-          config[:aws_session_token]
+          config[:aws_session_token],
+          config[:http_proxy]
         )
       end
 

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for EC2 Test Kitchen driver
-    EC2_VERSION = "0.10.0.dev.1"
+    EC2_VERSION = "0.9.2"
   end
 end

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -106,6 +106,27 @@ describe Kitchen::Driver::Aws::Client do
       client
       expect(Aws.config[:region]).to eq("us-west-1")
     end
+
+    context "when provided all optional parameters" do
+      let(:client) {
+        Kitchen::Driver::Aws::Client.new(
+          "us-west-1",
+          "profile_name",
+          "access_key_id",
+          "secret_access_key",
+          "session_token",
+          "http_proxy"
+        )
+      }
+      let(:creds) { double("creds") }
+      it "Sets the AWS config" do
+        expect(Kitchen::Driver::Aws::Client).to receive(:get_credentials).and_return(creds)
+        client
+        expect(Aws.config[:region]).to eq("us-west-1")
+        expect(Aws.config[:credentials]).to eq(creds)
+        expect(Aws.config[:http_proxy]).to eq("http_proxy")
+      end
+    end
   end
 
   it "returns a client" do


### PR DESCRIPTION
Fixes https://github.com/test-kitchen/kitchen-ec2/issues/126

\cc @fnichol @litjoco

I added a config option that defaults to `ENV['HTTP_PROXY']`.  @litjoco as you pointed out, there is only 1 `:http_proxy` setting available in the AWS Ruby SDK V2, so we cannot specify a different `:https_proxy`.  But I set up a local [mitmproxy](https://mitmproxy.org/doc/mitmproxy.html) and tested that HTTPS requests worked through this proxy when specifying `ENV['HTTP_PROXY']`

But because all the requests to AWS were actually https requests, I'm thinking of trying to first default to `ENV['HTTPS_PROXY']` then falling back to `ENV['HTTP_PROXY']`.  Would this support your use case better?  Or are both environment variables typically pointing to the same proxy?

I'm also adding in the 0.9.2 release prep here because this is the last PR I'm waiting on for that release.