### PR TITLE
Make Ec2#create_ec2_json work on Windows guests

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -369,9 +369,12 @@ module Kitchen
       end
 
       def create_ec2_json(state)
-        instance.transport.connection(state).execute(
-          "sudo mkdir -p /etc/chef/ohai/hints;sudo touch /etc/chef/ohai/hints/ec2.json"
-        )
+        if instance.transport.windows_os?
+          cmd = "mkdir c:\\chef\\ohai\\hints; echo $null >> c:\\chef\\ohai\\hints\\ec2.json"
+        else
+          cmd = "sudo mkdir -p /etc/chef/ohai/hints;sudo touch /etc/chef/ohai/hints/ec2.json"
+        end
+        instance.transport.connection(state).execute(cmd)
       end
 
     end


### PR DESCRIPTION
The Kitchen::Driver::Ec2#create_ec2_json method works on Linux and OS X but not on Windows.

This PR fixes the following error when the method runs against a Windows guest:

```
       Waiting for WinRM service on http://ec2-52-64-76-82.ap-southeast-2.compute.amazonaws.com:5985/wsman, retrying in 3 seconds
       [WinRM] Established
$$$$$$ sudo : The term 'sudo' is not recognized as the name of a cmdlet, function,
$$$$$$ script file, or operable program. Check the spelling of the name, or if a path
$$$$$$ was included, verify that the path is correct and try again.
$$$$$$ At line:1 char:1
$$$$$$ + sudo mkdir -p /etc/chef/ohai/hints;sudo touch /etc/chef/ohai/hints/ec2.json
$$$$$$ + ~~~~
$$$$$$     + CategoryInfo          : ObjectNotFound: (sudo:String) [], CommandNotFoun
$$$$$$    dException
$$$$$$     + FullyQualifiedErrorId : CommandNotFoundException
$$$$$$
$$$$$$ sudo : The term 'sudo' is not recognized as the name of a cmdlet, function,
$$$$$$ script file, or operable program. Check the spelling of the name, or if a path
$$$$$$ was included, verify that the path is correct and try again.
$$$$$$ At line:1 char:36
$$$$$$ + sudo mkdir -p /etc/chef/ohai/hints;sudo touch /etc/chef/ohai/hints/ec2.json
$$$$$$ +                                    ~~~~
$$$$$$     + CategoryInfo          : ObjectNotFound: (sudo:String) [], CommandNotFoun
$$$$$$    dException
$$$$$$     + FullyQualifiedErrorId : CommandNotFoundException
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #create action: [WinRM exited (1) for command: [sudo mkdir -p /etc/chef/ohai/hints;sudo touch /etc/chef/ohai/hints/ec2.json]]
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```