### PR TITLE
Providing logger to instance_generator, fixes #142

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,6 @@ Metrics/CyclomaticComplexity:
 
 Metrics/PerceivedComplexity:
   Max: 30
+
+Metrics/AbcSize:
+  Max: 60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.9.4 / 2015-06-03
+
+### Bug Fixes
+
+* Pull Request [#142][]: Fixing NoMethodError, providing logger to instance_generator
+
+### New Features
+
+### Improvements
+
 ## 0.9.3 / 2015-05-29
 
 ### Bug Fixes
@@ -154,6 +164,7 @@
 [#128]: https://github.com/test-kitchen/kitchen-ec2/issues/128
 [#131]: https://github.com/test-kitchen/kitchen-ec2/issues/131
 [#140]: https://github.com/test-kitchen/kitchen-ec2/issues/140
+[#142]: https://github.com/test-kitchen/kitchen-ec2/issues/142
 [@Atalanta]: https://github.com/Atalanta
 [@Igorshp]: https://github.com/Igorshp
 [@JamesAwesome]: https://github.com/JamesAwesome

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -30,13 +30,12 @@ module Kitchen
       # @author Tyler Ball <tball@chef.io>
       class InstanceGenerator
 
-        include Logging
+        attr_reader :config, :ec2, :logger
 
-        attr_reader :config, :ec2
-
-        def initialize(config, ec2)
+        def initialize(config, ec2, logger)
           @config = config
           @ec2 = ec2
+          @logger = logger
         end
 
         # Transform the provided config into the hash to send to AWS.  Some fields
@@ -125,6 +124,7 @@ module Kitchen
         # If the provided bdms match the root device in the AMI, emit log that
         # states this
         def debug_if_root_device(bdms)
+          return if bdms.nil? || bdms.empty?
           image_id = config[:image_id]
           image = ec2.resource.image(image_id)
           begin
@@ -136,7 +136,7 @@ module Kitchen
           end
           bdms.find { |bdm|
             if bdm[:device_name] == root_device_name
-              info("Overriding root device [#{root_device_name}] from image [#{image_id}]")
+              logger.info("Overriding root device [#{root_device_name}] from image [#{image_id}]")
             end
           }
         end

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for EC2 Test Kitchen driver
-    EC2_VERSION = "0.10.0.dev.3"
+    EC2_VERSION = "0.9.4"
   end
 end

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -88,6 +88,12 @@ describe Kitchen::Driver::Ec2 do
       driver.finalize_config!(instance)
       expect(config[:availability_zone]).to eq("us-east-1b")
     end
+
+    it "expands the availability zone if provided as a letter" do
+      config[:availability_zone] = "d"
+      driver.finalize_config!(instance)
+      expect(config[:availability_zone]).to eq("us-east-1d")
+    end
   end
 
   describe "#hostname" do
@@ -171,6 +177,10 @@ describe Kitchen::Driver::Ec2 do
   end
 
   describe "#submit_server" do
+    before do
+      expect(driver).to receive(:instance).at_least(:once).and_return(instance)
+    end
+
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
       expect(client).to receive(:create_instance).with(:min_count => 1, :max_count => 1)
@@ -183,6 +193,10 @@ describe Kitchen::Driver::Ec2 do
     let(:response) {
       { :spot_instance_requests => [{ :spot_instance_request_id => "id" }] }
     }
+
+    before do
+      expect(driver).to receive(:instance).at_least(:once).and_return(instance)
+    end
 
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})


### PR DESCRIPTION
fixes https://github.com/test-kitchen/kitchen-ec2/issues/142

Also brought the `availability_zone` behavior in line with the README

\cc @joelhandwell @fnichol @metadave @randomcamel