### PR TITLE
Query correct instance object for hostname fixes #148

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ Style/FileName:
   Exclude:
     - 'data/**/*'
 
+Style/Lambda:
+  Enabled: false
+
 Style/Next:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.9.4 / 2015-06-05
+
+### Bug Fixes
+
+* Pull Request [#151][]: Fixing a regression where we are fetching the hostname from an old server object even after waiting for it to update, causing us to get back an invalid hostname
+
+### New Features
+
+### Improvements
+
 ## 0.9.4 / 2015-06-03
 
 ### Bug Fixes
@@ -165,6 +175,7 @@
 [#131]: https://github.com/test-kitchen/kitchen-ec2/issues/131
 [#140]: https://github.com/test-kitchen/kitchen-ec2/issues/140
 [#142]: https://github.com/test-kitchen/kitchen-ec2/issues/142
+[#151]: https://github.com/test-kitchen/kitchen-ec2/issues/151
 [@Atalanta]: https://github.com/Atalanta
 [@Igorshp]: https://github.com/Igorshp
 [@JamesAwesome]: https://github.com/JamesAwesome

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for EC2 Test Kitchen driver
-    EC2_VERSION = "0.10.0.dev.4"
+    EC2_VERSION = "0.9.5"
   end
 end


### PR DESCRIPTION
I introduced a regression where we use an old aws object to fetch connection information instead of the new object we queried to make sure it is ready

fixes https://github.com/test-kitchen/kitchen-ec2/issues/148