### PR TITLE
Remove useless log message

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -175,7 +175,6 @@ module Kitchen
         return if state[:server_id]
 
         info(Kitchen::Util.outdent!(<<-END))
-          Creating <#{state[:server_id]}>...
           If you are not using an account that qualifies under the AWS
           free-tier, you may be charged to run these suites. The charge
           should be minimal, but neither Test Kitchen nor its maintainers


### PR DESCRIPTION
AFAICS, the `Creating <#{state[:server_id]}>...` message will always output `Creating <>...` because `state[:server_id]` is not set yet. Otherwise, `return if state[:server_id]` would have returned early from the `create` method.