### PR TITLE
Fix 'invalid char in json text' error

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -427,7 +427,7 @@ module Kitchen
 
       def create_ec2_json(state)
         if windows_os?
-          cmd = "mkdir \\etc\\chef\\ohai\\hints; echo $null >> \\etc\\chef\\ohai\\hints\\ec2.json"
+          cmd = "New-Item -Force C:\\chef\\ohai\\hints\\ec2.json -Type File"
         else
           cmd = "sudo mkdir -p /etc/chef/ohai/hints;sudo touch /etc/chef/ohai/hints/ec2.json"
         end


### PR DESCRIPTION
After further testing and closer inspection of the Chef logs, it seems my change in #134 introduced a different kind of error:

```
[2015-06-18T21:34:00+00:00] DEBUG: No data to collect for plugin Virtualization. Continuing...
[2015-06-18T21:34:00+00:00] DEBUG: No hints present for azure.
[2015-06-18T21:35:20+00:00] ERROR: Could not parse hint file at C:\chef\ohai\hints/ec2.json: lexical error: invalid char in json text.
                                       ÿþ
                     (right here) ------^

[2015-06-18T21:35:20+00:00] DEBUG: has_ec2_mac? == false
[2015-06-18T21:35:20+00:00] DEBUG: looks_like_ec2? == false
```

Apparently the method I used inserts a [UTF-16 byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-16). 

The fix in this PR creates an empty file with no BOM.