### PR TITLE
Adding block_device_mapping iops parameter, fixes #157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+* Pull Request #165: Added `ebs_iops` parameter to block_device_mappings, necessary when specifying volume type of `io1`
+
 ### New Features
 
 * Pull Request [#150][]: Added support for managing Windows hosts in AWS

--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ block_device_mappings:
     ebs_volume_size: 15
     ebs_delete_on_termination: true
     ebs_snapshot_id: snap-0015d0bc
+  - ebs_device_name: /dev/sdc
+    ebs_volume_size: 100
+    ebs_delete_on_termination: true
+    ebs_volume_type: io1
+    ebs_iops: 100
 ```
 
 The keys `ebs_device_name`, `ebs_volume_size` and `ebs_delete_on_termination` are required for every mapping.
@@ -280,7 +285,8 @@ storage config keys are present.
 
 The keys `ebs_volume_type`, `ebs_virtual_name` and `ebs_snapshot_id` are optional.  See
 [Amazon EBS Volume Types](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) to find out more about
-volume types. `ebs_volume_type` defaults to `standard` but can also be `gp2` or `io1`.
+volume types. `ebs_volume_type` defaults to `standard` but can also be `gp2` or `io1`.  If you specify `io1` you must
+also specify `ebs_iops`.
 
 If you have a block device mapping with a `ebs_device_name` equal to the root storage device name on your
 [image](#config-image-id) then the provided mapping will replace the settings in the image.

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -110,6 +110,7 @@ module Kitchen
               :device_name             => bdm[:ebs_device_name]
             }
             b[:ebs][:volume_type] = bdm[:ebs_volume_type] if bdm[:ebs_volume_type]
+            b[:ebs][:iops] = bdm[:ebs_iops] if bdm[:ebs_iops]
             b[:ebs][:snapshot_id] = bdm[:ebs_snapshot_id] if bdm[:ebs_snapshot_id]
             b[:virtual_name] = bdm[:ebs_virtual_name] if bdm[:ebs_virtual_name]
             b

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -114,6 +114,13 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
             :ebs_volume_type => "gp2",
             :ebs_snapshot_id => "id",
             :ebs_virtual_name => "test"
+          },
+          {
+            :ebs_volume_size => 100,
+            :ebs_delete_on_termination => true,
+            :ebs_device_name => "/dev/sda3",
+            :ebs_volume_type => "io1",
+            :ebs_iops => 100
           }
         ] }
       end
@@ -137,6 +144,15 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
               },
               :device_name => "/dev/sda2",
               :virtual_name => "test"
+            },
+            {
+              :ebs => {
+                :volume_size => 100,
+                :volume_type => "io1",
+                :iops => 100,
+                :delete_on_termination => true
+              },
+              :device_name => "/dev/sda3"
             }
           ]
         )


### PR DESCRIPTION
Necessary when specifying volume_type of io1.  Fixes #157 

\cc @fnichol @metadave @randomcamel