### PR TITLE
Allow `:security_group_ids` to accept a string value.

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -52,7 +52,7 @@ module Kitchen
             :private_ip_address           => config[:private_ip_address]
           }
           i[:block_device_mappings] = block_device_mappings unless block_device_mappings.empty?
-          i[:security_group_ids] = config[:security_group_ids] if config[:security_group_ids]
+          i[:security_group_ids] = Array(config[:security_group_ids]) if config[:security_group_ids]
           i[:user_data] = prepared_user_data if prepared_user_data
           if config[:iam_profile_name]
             i[:iam_instance_profile] = { :name => config[:iam_profile_name] }

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -363,6 +363,19 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
             }]
           )
         end
+
+        it "accepts a single string value" do
+          config[:security_group_ids] = "only-one"
+
+          expect(generator.ec2_instance_data).to include(
+            :network_interfaces => [{
+              :device_index => 0,
+              :associate_public_ip_address => true,
+              :delete_on_termination => true,
+              :groups => ["only-one"]
+            }]
+          )
+        end
       end
 
       context "and private_ip_address is provided" do


### PR DESCRIPTION
This allows a string to be passed as the value of the
`:security_group_ids` setting which be later be coerced into an array.

Closes #144