### PR TITLE
When security_group_ids is passed as a string we automatically make it an array, fixes #144

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -52,7 +52,7 @@ module Kitchen
             :private_ip_address           => config[:private_ip_address]
           }
           i[:block_device_mappings] = block_device_mappings unless block_device_mappings.empty?
-          i[:security_group_ids] = config[:security_group_ids] if config[:security_group_ids]
+          i[:security_group_ids] = Array(config[:security_group_ids]) if config[:security_group_ids]
           i[:user_data] = prepared_user_data if prepared_user_data
           if config[:iam_profile_name]
             i[:iam_instance_profile] = { :name => config[:iam_profile_name] }

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -338,11 +338,38 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
         end
       end
 
-      context "and security_group_ids is provided" do
+      context "and security_group_ids is provided as an array" do
         let(:config) do
           {
             :associate_public_ip => true,
-            :security_group_ids => ["sg-789"]
+            :security_group_ids => ["sg-789", "sg-123"]
+          }
+        end
+
+        it "adds a network_interfaces block" do
+          expect(generator.ec2_instance_data).to eq(
+            :placement => { :availability_zone => nil },
+            :instance_type => nil,
+            :ebs_optimized => nil,
+            :image_id => nil,
+            :key_name => nil,
+            :subnet_id => nil,
+            :private_ip_address => nil,
+            :network_interfaces => [{
+              :device_index => 0,
+              :associate_public_ip_address => true,
+              :delete_on_termination => true,
+              :groups => ["sg-789", "sg-123"]
+            }]
+          )
+        end
+      end
+
+      context "and security_group_ids is provided as an string" do
+        let(:config) do
+          {
+            :associate_public_ip => true,
+            :security_group_ids => "sg-789"
           }
         end
 


### PR DESCRIPTION
Fixes https://github.com/test-kitchen/kitchen-ec2/issues/144