### PR TITLE
Query Ubuntu AMI IDs

### DIFF
--- a/data/amis.json
+++ b/data/amis.json
@@ -1,96 +1,48 @@
 {
   "regions": {
     "ap-northeast-1": {
-      "ubuntu-10.04": "ami-8326b382",
-      "ubuntu-12.04": "ami-bb9a08ba",
-      "ubuntu-12.10": "ami-4556c544",
-      "ubuntu-13.04": "ami-97099a96",
-      "ubuntu-13.10": "ami-45f1a744",
-      "ubuntu-14.04": "ami-955c0c94",
       "centos-6.4": "ami-9ffa709e",
       "debian-7.1.0": "ami-f1f064f0",
       "windows-2012r2": "ami-28bc7428",
       "windows-2008r2": "ami-5ace065a"
     },
     "ap-southeast-1": {
-      "ubuntu-10.04": "ami-34713866",
-      "ubuntu-12.04": "ami-881c57da",
-      "ubuntu-12.10": "ami-3ce0a86e",
-      "ubuntu-13.04": "ami-4af5bd18",
-      "ubuntu-13.10": "ami-02e6b850",
-      "ubuntu-14.04": "ami-9a7c25c8",
       "centos-6.4": "ami-46f5bb14",
       "debian-7.1.0": "ami-fe8ac3ac",
       "windows-2012r2": "ami-062e1054",
       "windows-2008r2": "ami-30291762"
     },
     "ap-southeast-2": {
-      "ubuntu-10.04": "ami-2f009315",
-      "ubuntu-12.04": "ami-cb26b4f1",
-      "ubuntu-12.10": "ami-1703912d",
-      "ubuntu-13.04": "ami-8f32a0b5",
-      "ubuntu-13.10": "ami-e54423df",
-      "ubuntu-14.04": "ami-f3b1d6c9",
       "centos-6.4": "ami-9352c1a9",
       "debian-7.1.0": "ami-4e099a74",
       "windows-2012r2": "ami-6be19e51",
       "windows-2008r2": "ami-fdd8a7c7"
     },
     "eu-west-1": {
-      "ubuntu-10.04": "ami-bbadb0cf",
-      "ubuntu-12.04": "ami-d3b5aea7",
-      "ubuntu-12.10": "ami-6b62791f",
-      "ubuntu-13.04": "ami-6fd4cf1b",
-      "ubuntu-13.10": "ami-39eb3f4e",
-      "ubuntu-14.04": "ami-c112c5b6",
       "centos-6.4": "ami-75190b01",
       "debian-7.1.0": "ami-954559e1",
       "windows-2012r2": "ami-1387ed64",
       "windows-2008r2": "ami-1b97fd6c"
     },
     "sa-east-1": {
-      "ubuntu-10.04": "ami-962c898b",
-      "ubuntu-12.04": "ami-c905a1d4",
-      "ubuntu-12.10": "ami-e759fdfa",
-      "ubuntu-13.04": "ami-4b2b8f56",
-      "ubuntu-13.10": "ami-076cc21a",
-      "ubuntu-14.04": "ami-052b8518",
       "centos-6.4": "ami-a665c0bb",
       "debian-7.1.0": "ami-b03590ad",
       "windows-2012r2": "ami-7929ae64",
       "windows-2008r2": "ami-9331b68e"
     },
     "us-east-1": {
-      "ubuntu-10.04": "ami-1ab3ce73",
-      "ubuntu-12.04": "ami-2f115c46",
-      "ubuntu-12.10": "ami-4d5b1824",
-      "ubuntu-13.04": "ami-a73371ce",
-      "ubuntu-13.10": "ami-a65393ce",
-      "ubuntu-14.04": "ami-4a915c22",
       "centos-6.4": "ami-bf5021d6",
       "debian-7.1.0": "ami-50d9a439",
       "windows-2012r2": "ami-c01102a8",
       "windows-2008r2": "ami-c8c0d3a0"
     },
     "us-west-1": {
-      "ubuntu-10.04": "ami-848ba2c1",
-      "ubuntu-12.04": "ami-eaf0daaf",
-      "ubuntu-12.10": "ami-02220847",
-      "ubuntu-13.04": "ami-fe052fbb",
-      "ubuntu-13.10": "ami-bb2a2afe",
-      "ubuntu-14.04": "ami-d99a9a9c",
       "centos-6.4": "ami-5d456c18",
       "debian-7.1.0": "ami-1a9bb25f",
       "windows-2012r2": "ami-830ee0c7",
       "windows-2008r2": "ami-af04eaeb"
     },
     "us-west-2": {
-      "ubuntu-10.04": "ami-f19407c1",
-      "ubuntu-12.04": "ami-e6f36fd6",
-      "ubuntu-12.10": "ami-0c069b3c",
-      "ubuntu-13.04": "ami-4ade427a",
-      "ubuntu-13.10": "ami-c18ff1f1",
-      "ubuntu-14.04": "ami-b7720b87",
       "centos-6.4": "ami-b3bf2f83",
       "debian-7.1.0": "ami-158a1925",
       "windows-2012r2": "ami-c30a39f3",
@@ -109,8 +61,21 @@
     "windows-2008r2": "administrator",
     "windows-2012r2": "administrator"
   },
+  "ubuntu_releases": {
+    "ubuntu-10.04": "lucid",
+    "ubuntu-12.04": "precise",
+    "ubuntu-12.10": "quantal",
+    "ubuntu-13.04": "raring",
+    "ubuntu-13.10": "saucy",
+    "ubuntu-14.04": "trusty",
+    "ubuntu-14.10": "utopic",
+    "ubuntu-15.04": "vivid",
+    "ubuntu-15.10": "wily"
+  },
   "references": {
     "ubuntu": "http://uec-images.ubuntu.com/query/",
+    "ubuntu_ami": "https://github.com/jtimberman/ubuntu_ami",
+    "ubuntu_releases": "https://wiki.ubuntu.com/DevelopmentCodeNames",
     "debian": "https://wiki.debian.org/Cloud/AmazonEC2Image",
     "centos": "http://wiki.centos.org/Cloud/AWS",
     "windows": "http://aws.amazon.com/windows/"

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "excon"
   gem.add_dependency "multi_json"
   gem.add_dependency "aws-sdk", "~> 2"
+  gem.add_dependency "ubuntu_ami", "~> 0.4.1"
 
   gem.add_development_dependency "rspec",     "~> 3.2"
   gem.add_development_dependency "countloc",  "~> 0.4"

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -424,4 +424,18 @@ describe Kitchen::Driver::Ec2 do
     end
   end
 
+  describe "#default_ami" do
+    context "when platform is ubuntu" do
+      let(:config) { { :aws_ssh_key_id => "key" } }
+      let(:platform) { Kitchen::Platform.new(:name => "ubuntu-14.04") }
+      let(:ami_data) { %w[ ami-1305ef78 instance-store amd64 us-east-1 paravirtual ] }
+
+      it "queries an ami_id" do
+        expect(driver).to receive(:ubuntu_ami).with(config[:region], platform.name). \
+          and_return(Ubuntu::Ami.new(*ami_data))
+        expect(driver.default_ami).to eq(ami_data[0])
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
@tyler-ball sorry for the delay, I finally put something together for this. It works but I'm not thrilled with the organization of it and I'm happy to refactor if you could give me some comments. Thanks!

* The defaults for `arch`, `root_store`, and `virtualization_type` are based on the current images in `amis.json`