### PR TITLE
Trying :instance_running check before tagging

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -194,7 +194,7 @@ module Kitchen
         end
         info("Instance <#{server.id}> requested.")
         ec2.client.wait_until(
-          :instance_exists,
+          :instance_running,
           :instance_ids => [server.id]
         )
         tag_server(server)

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -338,7 +338,7 @@ describe Kitchen::Driver::Ec2 do
     shared_examples "common create" do
       it "successfully creates and tags the instance" do
         expect(actual_client).to receive(:wait_until).with(
-          :instance_exists,
+          :instance_running,
           :instance_ids => [server.id]
         )
         expect(driver).to receive(:tag_server).with(server)


### PR DESCRIPTION
The :instance_ready check passed but then trying to tag the instance raised a `Aws::EC2::Errors::InvalidInstanceIDNotFound - The instance ID 'i-b3dbea44' does not exist` error

\cc @jaym 