### PR TITLE
Add support for looking up AMIs with the EC2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ token) through config.  See the `aws_access_key_id` and `aws_secret_access_key`
 config sections below to see how to specify these in your .kitchen.yml or
 through environment variables.  If you would like to specify your session token
 use the environment variable `AWS_SESSION_TOKEN`.
-1. The shared credentials ini file at `~/.aws/credentials`.  You can specify 
+1. The shared credentials ini file at `~/.aws/credentials`.  You can specify
 multiple profiles in this file and select one with the `AWS_PROFILE`
 environment variable or the `shared_credentials_profile` driver config.  Read
 [this][credentials_docs] for more information.
@@ -89,7 +89,7 @@ environment variable or the `shared_credentials_profile` driver config.  Read
 metadata service to discover the local instance's IAM instance profile.
 
 This precedence order is taken from http://docs.aws.amazon.com/sdkforruby/api/index.html#Configuration
-  
+
 The first method attempted that works will be used.  IE, if you want to auth
 using the instance profile, you must not set any of the access key configs
 or environment variables, and you must not specify a `~/.aws/credentials`
@@ -97,7 +97,7 @@ file.
 
 Because the Test Kitchen test should be checked into source control and ran
 through CI we no longer recommend storing the AWS credentials in the
-`.kitchen.yml` file.  Instead, specify them as environment variables or in the 
+`.kitchen.yml` file.  Instead, specify them as environment variables or in the
 `~/.aws/credentials` file.
 
 ## Windows Configuration
@@ -185,6 +185,18 @@ The default is `["default"]`.
 The default will be determined by the `aws_region` chosen and the Platform
 name, if a default exists (see [amis.json][ami_json]). If a default cannot be
 computed, then the default is `nil`.
+
+### image\_search
+
+Searches the EC2 API for the latest AMI ID that matches the given [filters](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html).
+
+For example, a search for the latest AMI that matches a given image name looks
+like:
+
+```yaml
+image_search:
+  name: Windows_Server-2012-R2_RTM-English-64Bit-Base-*
+```
 
 ### region
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -171,8 +171,12 @@ module Kitchen
           config[:instance_type] = config[:flavor_id] || "m1.small"
         end
 
-        if config[:image_id].is_a?(Hash)
-          config[:image_id] = lookup_ami(config[:image_id])
+        if config[:image_id].nil?
+          if config[:image_search].nil?
+            config[:image_id] = instance.driver.default_ami
+          else
+            config[:image_id] = lookup_ami(config[:image_search])
+          end
         end
 
         self

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -171,14 +171,6 @@ module Kitchen
           config[:instance_type] = config[:flavor_id] || "m1.small"
         end
 
-        if config[:image_id].nil?
-          if config[:image_search].nil?
-            config[:image_id] = instance.driver.default_ami
-          else
-            config[:image_id] = lookup_ami(config[:image_search])
-          end
-        end
-
         self
       end
 
@@ -270,6 +262,8 @@ module Kitchen
         if instance.platform.name.start_with?("ubuntu")
           ami = ubuntu_ami(config[:region], instance.platform.name)
           ami && ami.name
+        elsif !config[:image_search].nil?
+          lookup_ami(config[:image_search])
         else
           region = amis["regions"][config[:region]]
           region && region[instance.platform.name]

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -93,7 +93,7 @@ describe Kitchen::Driver::Ec2 do
 
     it "turns an image_id hash into a image_id string" do
       config[:image_id] = { :name => "ami_name" }
-      expect(driver).to receive(:lookup_ami).with({ :name => "ami_name" }). \
+      expect(driver).to receive(:lookup_ami).with( :name => "ami_name" ). \
         and_return("ami-a1b2c3d4")
       driver.finalize_config!(instance)
       expect(config[:image_id]).to eq("ami-a1b2c3d4")
@@ -433,9 +433,12 @@ describe Kitchen::Driver::Ec2 do
   end
 
   describe "#lookup_ami" do
+    let(:resource) { double("actual resource") }
+
     let(:filters) { { :name => "ami_name" } }
-    let(:aws_filters) { { :filters => [{:name => "name", values: ["ami_name"] }] } }
-    let(:resource) { double('actual resource') }
+    let(:aws_filters) do
+      { :filters => [{ :name => "name", :values => ["ami_name"] }] }
+    end
 
     before do
       allow(client).to receive(:resource).and_return(resource)

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -90,52 +90,6 @@ describe Kitchen::Driver::Ec2 do
       driver.finalize_config!(instance)
       expect(config[:availability_zone]).to eq("us-east-1d")
     end
-
-    context "when image_id is not provided" do
-      context "when image_search is not provided" do
-        let(:default_ami) { 'ami-xxxxxxxx' }
-
-        before do
-          allow(instance).to receive(:driver). \
-            and_return(double('driver', default_ami: default_ami))
-        end
-
-        it "sets image_id to the default image" do
-          config[:image_id] = nil
-          driver.finalize_config!(instance)
-          expect(config[:image_id]).to eq(default_ami)
-        end
-
-        it "does not use image_search" do
-          config[:image_id] = nil
-          config[:image_search] = nil
-          driver.finalize_config!(instance)
-          expect(driver).to_not receive(:lookup_ami)
-        end
-      end
-
-      context "when image_search is provided" do
-        let(:found_ami) { 'ami-yyyyyyyy' }
-
-        it "searches for an image ID" do
-          config[:image_id] = nil
-          config[:image_search] = { :name => "ami_name" }
-          expect(driver).to receive(:lookup_ami).with(:name => "ami_name"). \
-            and_return(found_ami)
-          driver.finalize_config!(instance)
-          expect(config[:image_id]).to eq(found_ami)
-        end
-      end
-    end
-
-    context "when image_id is provided" do
-      it "does not use image_search" do
-        config[:image_id] = "a"
-        config[:image_search] = {}
-        driver.finalize_config!(instance)
-        expect(driver).to_not receive(:lookup_ami)
-      end
-    end
   end
 
   describe "#hostname" do
@@ -524,6 +478,17 @@ describe Kitchen::Driver::Ec2 do
         expect(driver).to receive(:ubuntu_ami).with(config[:region], platform.name). \
           and_return(Ubuntu::Ami.new(*ami_data))
         expect(driver.default_ami).to eq(ami_data[0])
+      end
+    end
+
+    context "when ami_search is provided" do
+      let(:config) { { :image_search => {} } }
+      let(:ami_id) { "ami-xxxxxxxx" }
+
+      it "searches for an image id" do
+        expect(driver).to receive(:lookup_ami).with(config[:image_search]). \
+          and_return(ami_id)
+        expect(driver.default_ami).to eq(ami_id)
       end
     end
   end

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -93,7 +93,7 @@ describe Kitchen::Driver::Ec2 do
 
     it "turns an image_id hash into a image_id string" do
       config[:image_id] = { :name => "ami_name" }
-      expect(driver).to receive(:lookup_ami).with( :name => "ami_name" ). \
+      expect(driver).to receive(:lookup_ami).with(:name => "ami_name"). \
         and_return("ami-a1b2c3d4")
       driver.finalize_config!(instance)
       expect(config[:image_id]).to eq("ami-a1b2c3d4")


### PR DESCRIPTION
Addresses #147. When a hash of filters are provided for the image_id it will try to find the AMI with the most recent creation date that matches the supplied filters.

Example usage (.kitchen.yml):
```yaml
platforms:
  - name: windows2012r2
    driver:
      image_id:
        name: Windows_Server-2012-R2_RTM-English-64Bit-Base-*
```

Example usage (amis.json):
```json
{
  "regions": {
    "ap-southeast-2": {
      "windows-2012r2": {
        "name": "Windows_Server-2012-R2_RTM-English-64Bit-Base-*"
      }
    }
  }
}
```