### PR TITLE
Adding better retry logic to creation, fixes #179 (hopefully)

### DIFF
--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "multi_json"
   gem.add_dependency "aws-sdk", "~> 2"
   gem.add_dependency "ubuntu_ami", "~> 0.4.1"
+  gem.add_dependency "retryable", "~> 2.0"
 
   gem.add_development_dependency "rspec",     "~> 3.2"
   gem.add_development_dependency "countloc",  "~> 0.4"

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -337,10 +337,7 @@ describe Kitchen::Driver::Ec2 do
 
     shared_examples "common create" do
       it "successfully creates and tags the instance" do
-        expect(actual_client).to receive(:wait_until).with(
-          :instance_running,
-          :instance_ids => [server.id]
-        )
+        expect(server).to receive(:wait_until_exists)
         expect(driver).to receive(:tag_server).with(server)
         expect(driver).to receive(:wait_until_ready).with(server, state)
         expect(transport).to receive_message_chain("connection.wait_until_ready")


### PR DESCRIPTION
The AWS Waiters still appear to be not correctly waiting for existence (see https://github.com/aws/aws-sdk-ruby/issues/859).  So adding better retry logic and outputting.

\cc @jaym @fnichol 

Fixes #179 
Rolls back #171 because that waited too long to provide output