### PR TITLE
Fix intermittent failures by waiting for instance to exist

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -193,6 +193,12 @@ module Kitchen
           server = submit_server
         end
         info("Instance <#{server.id}> requested.")
+        # We have to wait until the instance exists before we can wait for it to
+        # run ... and we have to wait until it is running before we can tag it.
+        ec2.client.wait_until(
+          :instance_exists,
+          :instance_ids => [server.id]
+        )
         ec2.client.wait_until(
           :instance_running,
           :instance_ids => [server.id]

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -338,6 +338,10 @@ describe Kitchen::Driver::Ec2 do
     shared_examples "common create" do
       it "successfully creates and tags the instance" do
         expect(actual_client).to receive(:wait_until).with(
+          :instance_exists,
+          :instance_ids => [server.id]
+        )
+        expect(actual_client).to receive(:wait_until).with(
           :instance_running,
           :instance_ids => [server.id]
         )


### PR DESCRIPTION
before checking if it's running. Fixes #138 for realer