### PR TITLE
Will provide support for ephemeral block_device_mappings

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -103,7 +103,7 @@ module Kitchen
           # Convert the provided keys to what AWS expects
           bdms = bdms.map do |bdm|
             b = {}
-            if bdm.has_key?(:ebs_device_name)
+            if bdm.key?(:ebs_device_name)
               b = {
                 :ebs => {
                   :volume_size           => bdm[:ebs_volume_size],
@@ -116,7 +116,7 @@ module Kitchen
               b[:ebs][:snapshot_id] = bdm[:ebs_snapshot_id] if bdm[:ebs_snapshot_id]
               b[:virtual_name] = bdm[:ebs_virtual_name] if bdm[:ebs_virtual_name]
             else
-              #ephemeral drive
+              # ephemeral drive
               b = {
                 :virtual_name   => bdm[:virtual_name],
                 :device_name    => bdm[:device_name]

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -102,17 +102,26 @@ module Kitchen
 
           # Convert the provided keys to what AWS expects
           bdms = bdms.map do |bdm|
-            b = {
-              :ebs => {
-                :volume_size           => bdm[:ebs_volume_size],
-                :delete_on_termination => bdm[:ebs_delete_on_termination]
-              },
-              :device_name             => bdm[:ebs_device_name]
-            }
-            b[:ebs][:volume_type] = bdm[:ebs_volume_type] if bdm[:ebs_volume_type]
-            b[:ebs][:iops] = bdm[:ebs_iops] if bdm[:ebs_iops]
-            b[:ebs][:snapshot_id] = bdm[:ebs_snapshot_id] if bdm[:ebs_snapshot_id]
-            b[:virtual_name] = bdm[:ebs_virtual_name] if bdm[:ebs_virtual_name]
+            b = {}
+            if bdm.has_key?(:ebs_device_name)
+              b = {
+                :ebs => {
+                  :volume_size           => bdm[:ebs_volume_size],
+                  :delete_on_termination => bdm[:ebs_delete_on_termination]
+                },
+                :device_name             => bdm[:ebs_device_name]
+              }
+              b[:ebs][:volume_type] = bdm[:ebs_volume_type] if bdm[:ebs_volume_type]
+              b[:ebs][:iops] = bdm[:ebs_iops] if bdm[:ebs_iops]
+              b[:ebs][:snapshot_id] = bdm[:ebs_snapshot_id] if bdm[:ebs_snapshot_id]
+              b[:virtual_name] = bdm[:ebs_virtual_name] if bdm[:ebs_virtual_name]
+            else
+              #ephemeral drive
+              b = {
+                :virtual_name   => bdm[:virtual_name],
+                :device_name    => bdm[:device_name]
+              }
+            end
             b
           end
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -116,12 +116,16 @@ module Kitchen
       validations[:block_device_mappings] = lambda do |_attr, val, _driver|
         unless val.nil?
           val.each do |bdm|
-            unless bdm.keys.include?(:ebs_volume_size) &&
+            if bdm.keys.include?(:ebs_volume_size) &&
                 bdm.keys.include?(:ebs_delete_on_termination) &&
                 bdm.keys.include?(:ebs_device_name)
+            elsif bdm.keys.include?(:device_name) &&
+                  bdm.keys.include?(:virtual_name)
+            else
               raise "Every :block_device_mapping must include the keys :ebs_volume_size, " \
-                ":ebs_delete_on_termination and :ebs_device_name"
-            end
+                ":ebs_delete_on_termination and :ebs_device_name for EBS devices \
+                OR device_name, virtual_name for Ephemeral devices"
+            endd
           end
         end
       end

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -120,7 +120,7 @@ module Kitchen
                 bdm.keys.include?(:ebs_delete_on_termination) &&
                 bdm.keys.include?(:ebs_device_name)
             elsif bdm.keys.include?(:device_name) &&
-                  bdm.keys.include?(:virtual_name)
+                bdm.keys.include?(:virtual_name)
             else
               raise "Every :block_device_mapping must include the keys :ebs_volume_size, " \
                 ":ebs_delete_on_termination and :ebs_device_name for EBS devices \

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -125,7 +125,7 @@ module Kitchen
               raise "Every :block_device_mapping must include the keys :ebs_volume_size, " \
                 ":ebs_delete_on_termination and :ebs_device_name for EBS devices \
                 OR device_name, virtual_name for Ephemeral devices"
-            endd
+            end
           end
         end
       end

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -222,6 +222,72 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           ]
         )
       end
+
+    end
+
+    context "when populated with ephemeral drive config" do
+      let(:config) do
+        { :block_device_mappings => [
+          {
+            :device_name => "/dev/xvda",
+            :virtual_name => "ephemeral0"
+          }
+        ] }
+      end
+
+      it "returns the same mappings" do
+        expect(generator.block_device_mappings).to match(
+          [
+            {
+              :device_name => "/dev/xvda",
+              :virtual_name => "ephemeral0"
+            }
+          ]
+        )
+      end
+
+    end
+
+    context "when populated with ebs and ephemeral mappings" do
+      let(:config) do
+        { :block_device_mappings => [
+          {
+            :ebs_volume_size => 13,
+            :ebs_delete_on_termination => true,
+            :ebs_device_name => "/dev/xvda"
+          },
+          {
+            :device_name => "/dev/xvdb",
+            :virtual_name => "ephemeral0"
+          },
+          {
+            :device_name => "/dev/xvdc",
+            :virtual_name => "ephemeral1"
+          }
+        ] }
+      end
+
+      it "returns the transformed mappings" do
+        expect(generator.block_device_mappings).to match(
+          [
+            {
+              :ebs => {
+                :volume_size => 13,
+                :delete_on_termination => true
+              },
+              :device_name => "/dev/xvda"
+            },
+            {
+              :device_name => "/dev/xvdb",
+              :virtual_name => "ephemeral0"
+            },
+            {
+              :device_name => "/dev/xvdc",
+              :virtual_name => "ephemeral1"
+            }
+          ]
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Resolves issue #172 

Example of ephemeral drives used on the same instance in conjunction with an ebs device, in kitchen.yml:
```yaml
      block_device_mappings:
        - ebs_device_name: /dev/xvda
          ebs_volume_type: gp2
          ebs_volume_size: 8
          ebs_delete_on_termination: true
        - device_name: /dev/xvdb
          virtual_name: ephemeral0
        - device_name: /dev/xvdc
          virtual_name: ephemeral1
```