### PR TITLE
Add support for looking up Private DNS Name for hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,13 +325,21 @@ If you don't set this it will default to whatever DHCP address EC2 hands out.
 
 ### interface
 
-The place from which to derive the hostname for communicating with the instance.  May be `dns`, `public` or `private`.  If this is unset, the driver will derive the hostname by failing back in the following order:
+The place from which to derive the hostname for communicating with the instance.  May be `dns`, `public`, `private`, `private_dns`.  If this is unset, the driver will derive the hostname by failing back in the following order:
 
 1. DNS Name
 2. Public IP Address
 3. Private IP Address
+4. Private DNS Name
 
-The default is unset.
+The default is unset. Under normal circumstances, the lookup will return the `Private IP Address`.
+
+If the `Private DNS Name` is preferred over the private IP, it must be specified in the `.kitchen.yml` file
+
+```ruby
+driver:
+  interface: private_dns
+```
 
 ### ssh\_key
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ If you don't set this it will default to whatever DHCP address EC2 hands out.
 
 ### interface
 
-The place from which to derive the hostname for communicating with the instance.  May be `dns`, `public`, `private`, `private_dns`.  If this is unset, the driver will derive the hostname by failing back in the following order:
+The place from which to derive the hostname for communicating with the instance.  May be `dns`, `public`, `private` or `private_dns`.  If this is unset, the driver will derive the hostname by failing back in the following order:
 
 1. DNS Name
 2. Public IP Address

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -431,9 +431,9 @@ module Kitchen
       INTERFACE_TYPES =
         {
           "dns" => "public_dns_name",
-          "private_dns" => "private_dns_name",
           "public" => "public_ip_address",
-          "private" => "private_ip_address"
+          "private" => "private_ip_address",
+          "private_dns" => "private_dns_name"
         }
 
       #

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -431,6 +431,7 @@ module Kitchen
       INTERFACE_TYPES =
         {
           "dns" => "public_dns_name",
+          "private_dns" => "private_dns_name",
           "public" => "public_ip_address",
           "private" => "private_ip_address"
         }

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -94,11 +94,13 @@ describe Kitchen::Driver::Ec2 do
 
   describe "#hostname" do
     let(:public_dns_name) { nil }
+    let(:private_dns_name) { nil }
     let(:public_ip_address) { nil }
     let(:private_ip_address) { nil }
     let(:server) {
       double("server",
         :public_dns_name => public_dns_name,
+        :private_dns_name => private_dns_name,
         :public_ip_address => public_ip_address,
         :private_ip_address => private_ip_address
       )
@@ -122,9 +124,23 @@ describe Kitchen::Driver::Ec2 do
       it "returns private_ip_address when requested" do
         expect(driver.hostname(server, "private")).to eq(private_ip_address)
       end
+      it "returns private_dns_name when requested" do
+        expect(driver.hostname(server, "private_dns")).to eq(private_dns_name)
+      end
+    end
+
+    context "private_dns_name is populated" do
+      let(:private_dns_name) { "private_dns_name" }
+
+      it "returns the private_dns_name" do
+        expect(driver.hostname(server)).to eq(private_dns_name)
+      end
+
+      include_examples "an interface type provided"
     end
 
     context "private_ip_address is populated" do
+      let(:private_dns_name) { "private_dns_name" }
       let(:private_ip_address) { "10.0.0.1" }
 
       it "returns the private_ip_address" do
@@ -135,6 +151,7 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context "public_ip_address is populated" do
+      let(:private_dns_name) { "private_dns_name" }
       let(:private_ip_address) { "10.0.0.1" }
       let(:public_ip_address) { "127.0.0.1" }
 
@@ -146,6 +163,7 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context "public_dns_name is populated" do
+      let(:private_dns_name) { "private_dns_name" }
       let(:private_ip_address) { "10.0.0.1" }
       let(:public_ip_address) { "127.0.0.1" }
       let(:public_dns_name) { "public_dns_name" }
@@ -167,6 +185,13 @@ describe Kitchen::Driver::Ec2 do
         let(:private_ip_address) { "10.0.0.1" }
         it "returns the private_ip_address" do
           expect(driver.hostname(server)).to eq(private_ip_address)
+        end
+
+        context "and private_dns_name is populated" do
+          let(:private_dns_name) { "private_dns_name" }
+          it "returns the private_ip_address" do
+            expect(driver.hostname(server)).to eq(private_ip_address)
+          end
         end
       end
     end


### PR DESCRIPTION
In some circumstances - for example proxy settings that are configurable on hostnames - the `private_dns_name` is preferred over the `private_ip_address`

When `private_dns` is provided as the option in `.kitchen.yml`, the value of `private_dns_name` will be returned

```ruby
driver:
  interface: private_dns
```

When this option is unset, the `private_ip_address` will be returned as in the current implementation