### PR TITLE
Add support for CentOS 7

### DIFF
--- a/data/amis.json
+++ b/data/amis.json
@@ -2,48 +2,56 @@
   "regions": {
     "ap-northeast-1": {
       "centos-6.4": "ami-9ffa709e",
+      "centos-7": "ami-89634988",
       "debian-7.1.0": "ami-f1f064f0",
       "windows-2012r2": "ami-28bc7428",
       "windows-2008r2": "ami-5ace065a"
     },
     "ap-southeast-1": {
       "centos-6.4": "ami-46f5bb14",
+      "centos-7": "ami-aea582fc",
       "debian-7.1.0": "ami-fe8ac3ac",
       "windows-2012r2": "ami-062e1054",
       "windows-2008r2": "ami-30291762"
     },
     "ap-southeast-2": {
       "centos-6.4": "ami-9352c1a9",
+      "centos-7": "ami-bd523087",
       "debian-7.1.0": "ami-4e099a74",
       "windows-2012r2": "ami-6be19e51",
       "windows-2008r2": "ami-fdd8a7c7"
     },
     "eu-west-1": {
       "centos-6.4": "ami-75190b01",
+      "centos-7": "ami-e4ff5c93",
       "debian-7.1.0": "ami-954559e1",
       "windows-2012r2": "ami-1387ed64",
       "windows-2008r2": "ami-1b97fd6c"
     },
     "sa-east-1": {
       "centos-6.4": "ami-a665c0bb",
+      "centos-7": "ami-bf9520a2",
       "debian-7.1.0": "ami-b03590ad",
       "windows-2012r2": "ami-7929ae64",
       "windows-2008r2": "ami-9331b68e"
     },
     "us-east-1": {
       "centos-6.4": "ami-bf5021d6",
+      "centos-7": "ami-96a818fe",
       "debian-7.1.0": "ami-50d9a439",
       "windows-2012r2": "ami-c01102a8",
       "windows-2008r2": "ami-c8c0d3a0"
     },
     "us-west-1": {
       "centos-6.4": "ami-5d456c18",
+      "centos-7": "ami-6bcfc42e",
       "debian-7.1.0": "ami-1a9bb25f",
       "windows-2012r2": "ami-830ee0c7",
       "windows-2008r2": "ami-af04eaeb"
     },
     "us-west-2": {
       "centos-6.4": "ami-b3bf2f83",
+      "centos-7": "ami-c7d092f7",
       "debian-7.1.0": "ami-158a1925",
       "windows-2012r2": "ami-c30a39f3",
       "windows-2008r2": "ami-adf8cb9d"
@@ -59,6 +67,7 @@
     "ubuntu-15.04": "ubuntu",
     "ubuntu-15.10": "ubuntu",
     "centos-6.4": "root",
+    "centos-7": "centos",
     "debian-7.1.0": "admin",
     "windows-2008r2": "administrator",
     "windows-2012r2": "administrator"

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -255,9 +255,9 @@ module Kitchen
         release = amis["ubuntu_releases"][platform_name]
         Ubuntu.release(release).amis.find do |ami|
           ami.arch == "amd64" &&
-            ami.root_store == "instance-store" &&
+            ami.root_store == "ebs" &&
             ami.region == region &&
-            ami.virtualization_type == "paravirtual"
+            ami.virtualization_type == "hvm"
         end
       end
 

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for EC2 Test Kitchen driver
-    EC2_VERSION = "1.0.0.dev.0"
+    EC2_VERSION = "1.0.0.dev.1"
   end
 end


### PR DESCRIPTION
This patch adds images for CentOS 7 across all Regions and moves from the default of paravirtualisation and instance-store backed images to HVM and EBS which is rapidly becoming the default for images across EC2 (and is also required for CentOS 7 AMI's!)