### PR TITLE
Default instance type change, and Ubuntu AMI search options to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The AWS [session token][credentials_docs] to use.
 
 The EC2 [instance type][instance_docs] (also known as size) to use.
 
-The default is `"m1.small"`.
+The default is `"t2.micro"`.
 
 ### security_group_ids
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -266,9 +266,9 @@ module Kitchen
         release = amis["ubuntu_releases"][platform_name]
         Ubuntu.release(release).amis.find do |ami|
           ami.arch == "amd64" &&
-            ami.root_store == "instance-store" &&
+            ami.root_store == "ebs" &&
             ami.region == region &&
-            ami.virtualization_type == "paravirtual"
+            ami.virtualization_type == "hvm"
         end
       end
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -169,7 +169,7 @@ module Kitchen
         end
         # TODO: when we get rid of flavor_id, move this to a default
         if config[:instance_type].nil?
-          config[:instance_type] = config[:flavor_id] || "m1.small"
+          config[:instance_type] = config[:flavor_id] || "t2.micro"
         end
 
         self


### PR DESCRIPTION
Guys,

This PR makes 2 minor changes:

 * Changes Ubuntu search settings to use HVM/EBS instances
 * Sets the default instance type to `t2.micro`.

This brings the tool's default settings in line with usage guidelines for the free tier. Also, T2 instances generally use HVM/EBS, and not paravirtual/instance store.

PS: The old setting used `m1.*` types which are previous-generation.