### PR TITLE
Allow configuring retry_limit in Aws.config

### DIFF
--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -38,7 +38,8 @@ module Kitchen
           access_key_id = nil,
           secret_access_key = nil,
           session_token = nil,
-          http_proxy = nil
+          http_proxy = nil,
+          retry_limit = nil
         )
           creds = self.class.get_credentials(
             profile_name, access_key_id, secret_access_key, session_token
@@ -48,6 +49,7 @@ module Kitchen
             :credentials => creds,
             :http_proxy => http_proxy
           )
+          ::Aws.config.update(:retry_limit => retry_limit) unless retry_limit.nil?
         end
 
         # Try and get the credentials from an ordered list of locations

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -68,6 +68,7 @@ module Kitchen
       default_config :associate_public_ip, nil
       default_config :interface,           nil
       default_config :http_proxy,          ENV["HTTPS_PROXY"] || ENV["HTTP_PROXY"]
+      default_config :retry_limit,         3
 
       required_config :aws_ssh_key_id
       required_config :image_id
@@ -291,7 +292,8 @@ module Kitchen
           config[:aws_access_key_id],
           config[:aws_secret_access_key],
           config[:aws_session_token],
-          config[:http_proxy]
+          config[:http_proxy],
+          config[:retry_limit]
         )
       end
 

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -115,7 +115,8 @@ describe Kitchen::Driver::Aws::Client do
           "access_key_id",
           "secret_access_key",
           "session_token",
-          "http_proxy"
+          "http_proxy",
+          999
         )
       }
       let(:creds) { double("creds") }
@@ -125,6 +126,7 @@ describe Kitchen::Driver::Aws::Client do
         expect(Aws.config[:region]).to eq("us-west-1")
         expect(Aws.config[:credentials]).to eq(creds)
         expect(Aws.config[:http_proxy]).to eq("http_proxy")
+        expect(Aws.config[:retry_limit]).to eq(999)
       end
     end
   end


### PR DESCRIPTION
Setting this value high in .kitchen.yml allows us to run tons of suites in parallell without failing on api throttling