### PR TITLE
support duration for spot instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,13 @@ The price you bid in order to submit a spot request. An additional step will be 
 
 The default is `nil`.
 
+### block_duration_minutes
+
+The [specified duration](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#fixed-duration-spot-instances) for a spot instance, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+If no duration is set, the spot instance will remain active until it is terminated.
+
+The default is `nil`.
+
 ### `http_proxy`
 
 Specify a proxy to send AWS requests through.  Should be of the format `http://<host>:<port>`.

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -63,6 +63,7 @@ module Kitchen
       default_config :private_ip_address, nil
       default_config :iam_profile_name,   nil
       default_config :price,              nil
+      default_config :block_duration_minutes, nil
       default_config :retryable_tries,    60
       default_config :retryable_sleep,    5
       default_config :aws_access_key_id,  nil
@@ -323,6 +324,7 @@ module Kitchen
         request_data = {}
         request_data[:spot_price] = config[:price].to_s
         request_data[:launch_specification] = instance_generator.ec2_instance_data
+        request_data[:block_duration_minutes] = config[:block_duration_minutes] if config[:block_duration_minutes]
 
         response = ec2.client.request_spot_instances(request_data)
         spot_request_id = response[:spot_instance_requests][0][:spot_instance_request_id]

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -25,7 +25,7 @@ describe Kitchen::Driver::Ec2 do
 
   let(:logged_output) { StringIO.new }
   let(:logger)        { Logger.new(logged_output) }
-  let(:config)        { { :aws_ssh_key_id => "key", :image_id => "ami-1234567" } }
+  let(:config)        { { :aws_ssh_key_id => "key", :image_id => "ami-1234567", :block_duration_minutes => 60 } }
   let(:platform)      { Kitchen::Platform.new(:name => "fooos-99") }
   let(:transport)     { Kitchen::Transport::Dummy.new }
   let(:generator)     { instance_double(Kitchen::Driver::Aws::InstanceGenerator) }
@@ -177,7 +177,7 @@ describe Kitchen::Driver::Ec2 do
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
       expect(actual_client).to receive(:request_spot_instances).with(
-        :spot_price => "", :launch_specification => {}
+        :spot_price => "", :launch_specification => {}, :block_duration_minutes => 60
       ).and_return(response)
       expect(actual_client).to receive(:wait_until)
       expect(client).to receive(:get_instance_from_spot_request).with("id")


### PR DESCRIPTION
[Fixed-duration spot instances](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#fixed-duration-spot-instances) were [launched recently](https://aws.amazon.com/blogs/aws/new-ec2-spot-blocks-for-defined-duration-workloads/) and added to the AWS SDK. This PR adds support for the `block_duration_minutes` parameter in the [`request_spot_instances`](http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#request_spot_instances-instance_method) AWS sdk method, through a `:block_duration_minutes` config option.