### PR TITLE
Fix sudo dependency. Fixes #204

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -471,11 +471,19 @@ module Kitchen
         end
       end
 
+      #
+      # Returns the sudo command to use or empty string if sudo is not configured
+      #
+      def sudo_command
+        instance.provisioner[:sudo] ? instance.provisioner[:sudo_command].to_s : ''
+      end
+
       def create_ec2_json(state)
         if windows_os?
           cmd = "New-Item -Force C:\\chef\\ohai\\hints\\ec2.json -ItemType File"
         else
-          cmd = "sudo mkdir -p /etc/chef/ohai/hints;sudo touch /etc/chef/ohai/hints/ec2.json"
+          debug "Using sudo_command='#{sudo_command}' for ohai hints"
+          cmd = "#{sudo_command} mkdir -p /etc/chef/ohai/hints; #{sudo_command} touch /etc/chef/ohai/hints/ec2.json"
         end
         instance.transport.connection(state).execute(cmd)
       end

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -475,9 +475,10 @@ module Kitchen
       # Returns the sudo command to use or empty string if sudo is not configured
       #
       def sudo_command
-        instance.provisioner[:sudo] ? instance.provisioner[:sudo_command].to_s : ''
+        instance.provisioner[:sudo] ? instance.provisioner[:sudo_command].to_s : ""
       end
 
+      # rubocop:disable Metrics/MethodLength, Metrics/LineLength
       def create_ec2_json(state)
         if windows_os?
           cmd = "New-Item -Force C:\\chef\\ohai\\hints\\ec2.json -ItemType File"
@@ -488,7 +489,6 @@ module Kitchen
         instance.transport.connection(state).execute(cmd)
       end
 
-      # rubocop:disable Metrics/MethodLength, Metrics/LineLength
       def default_windows_user_data
         # Preparing custom static admin user if we defined something other than Administrator
         custom_admin_script = ""


### PR DESCRIPTION
The two ohai hint commands are respecting the `sudo` and `sudo_command` provisioner options. Fixes #204

The change [requires](http://kitchen.ci/blog/test-kitchen-1-4-0-release-notes) test-kitchen 1.4+, but this is covered by the current kitchen-ec2.gemspec
