### PR TITLE
Lookup id from tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,20 @@ instance.
 
 The default is `["default"]`.
 
+### `security_group_filter`
+
+The EC2 [security group][group_docs] which will be applied to the instance,
+specified by tag. Only one group can be specified this way.
+
+The default is unset, or `nil`.
+
+An example of usage:
+```yaml
+security_group_filter:
+  tag:   'Name'
+  value: 'example-group-name'
+```
+
 ### `region`
 
 **Required** The AWS [region][region_docs] to use.
@@ -258,6 +272,19 @@ Otherwise the default is `"us-east-1"`.
 The EC2 [subnet][subnet_docs] to use.
 
 The default is unset, or `nil`.
+
+### `subnet_filter`
+
+The EC2 [subnet][subnet_docs] to use, specified by tag.
+
+The default is unset, or `nil`.
+
+An example of usage:
+```yaml
+subnet_filter:
+  tag:   'Name'
+  value: 'example-subnet-name'
+```
 
 ### `tags`
 

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 require "base64"
-require 'aws-sdk'
+require "aws-sdk"
 
 module Kitchen
 
@@ -41,36 +41,39 @@ module Kitchen
         # Transform the provided config into the hash to send to AWS.  Some fields
         # can be passed in null, others need to be ommitted if they are null
         def ec2_instance_data # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-
           # Support for looking up security group id and subnet id using tags.
 
           if config[:subnet_id].nil? && config[:subnet_filter]
-            config[:subnet_id] = ::Aws::EC2::Client.new(region: config[:region]).describe_subnets(
-              filters: [
-                {
-                  name:   "tag:#{config[:subnet_filter][:tag]}",
-                  values: [config[:subnet_filter][:value]]
-                }
-              ]
-            )[0][0].subnet_id
+            config[:subnet_id] = ::Aws::EC2::Client.
+              new(:region => config[:region]).describe_subnets(
+                :filters => [
+                  {
+                    :name   => "tag:#{config[:subnet_filter][:tag]}",
+                    :values => [config[:subnet_filter][:value]]
+                  }
+                ]
+              )[0][0].subnet_id
 
             if config[:subnet_id].nil?
-              fail "The subnet tagged '#{config[:subnet_filter][:tag]}#{config[:subnet_filter][:value]}' does not exist!"
+              fail "The subnet tagged '#{config[:subnet_filter][:tag]}\
+              #{config[:subnet_filter][:value]}' does not exist!"
             end
           end
 
           if config[:security_group_ids].nil? && config[:security_group_filter]
-            config[:security_group_ids] = [::Aws::EC2::Client.new(region: config[:region]).describe_security_groups(
-              filters: [
-                {
-                  name:   "tag:#{config[:security_group_filter][:tag]}",
-                  values: [config[:security_group_filter][:value]]
-                }
-              ]
-            )[0][0].group_id]
+            config[:security_group_ids] = [::Aws::EC2::Client.
+              new(:region => config[:region]).describe_security_groups(
+                :filters => [
+                  {
+                    :name   => "tag:#{config[:security_group_filter][:tag]}",
+                    :values => [config[:security_group_filter][:value]]
+                  }
+                ]
+              )[0][0].group_id]
 
             if config[:security_group_ids].nil?
-              fail "The group tagged '#{config[:security_group_filter][:tag]}#{config[:security_group_filter][:value]}' does not exist!"
+              fail "The group tagged '#{config[:security_group_filter][:tag]}\
+              #{config[:security_group_filter][:value]}' does not exist!"
             end
           end
 

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -60,24 +60,24 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
   end
 
   describe "#ec2_instance_data" do
-    ec2_stub = Aws::EC2::Client.new(stub_responses: true)
+    ec2_stub = Aws::EC2::Client.new(:stub_responses => true)
 
     ec2_stub.stub_responses(
       :describe_subnets,
-      subnets: [
+      :subnets => [
         {
-          subnet_id: "s-123",
-          tags: [{ key: "foo", value: "bar" }]
+          :subnet_id  => "s-123",
+          :tags       => [{ :key => "foo", :value => "bar" }]
         }
       ]
     )
 
     ec2_stub.stub_responses(
       :describe_security_groups,
-      security_groups: [
+      :security_groups => [
         {
-          group_id: "sg-123",
-          tags: [{ key: "foo", value: "bar" }]
+          :group_id => "sg-123",
+          :tags => [{ :key => "foo", :value => "bar" }]
         }
       ]
     )
@@ -136,7 +136,14 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
 
       it "generates id from the provided tag" do
         allow(::Aws::EC2::Client).to receive(:new).and_return(ec2_stub)
-        expect(ec2_stub).to receive(:describe_subnets).with({:filters=>[{:name=>"tag:foo", :values=>["bar"]}]}).and_return(ec2_stub.describe_subnets)
+        expect(ec2_stub).to receive(:describe_subnets).with(
+          :filters => [
+            {
+              :name => "tag:foo",
+              :values => ["bar"]
+            }
+          ]
+        ).and_return(ec2_stub.describe_subnets)
         expect(generator.ec2_instance_data[:subnet_id]).to eq("s-123")
       end
     end
@@ -161,7 +168,14 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
 
       it "generates id from the provided tag" do
         allow(::Aws::EC2::Client).to receive(:new).and_return(ec2_stub)
-        expect(ec2_stub).to receive(:describe_security_groups).with({:filters=>[{:name=>"tag:foo", :values=>["bar"]}]}).and_return(ec2_stub.describe_security_groups)
+        expect(ec2_stub).to receive(:describe_security_groups).with(
+          :filters => [
+            {
+              :name => "tag:foo",
+              :values => ["bar"]
+            }
+          ]
+        ).and_return(ec2_stub.describe_security_groups)
         expect(generator.ec2_instance_data[:security_group_ids]).to eq(["sg-123"])
       end
     end


### PR DESCRIPTION
Added feature which enables Subnet or Security Group ID lookup based on a Tag, if IDs are not provided.
