### PR TITLE
Allow PowerShell script execution

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -501,6 +501,8 @@ module Kitchen
         Kitchen::Util.outdent!(<<-EOH)
         <powershell>
         $logfile="C:\\Program Files\\Amazon\\Ec2ConfigService\\Logs\\kitchen-ec2.log"
+        # Allow script execution
+        Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force
         #PS Remoting and & winrm.cmd basic config
         Enable-PSRemoting -Force -SkipNetworkProfileCheck
         & winrm.cmd set winrm/config '@{MaxTimeoutms="1800000"}' >> $logfile


### PR DESCRIPTION
Windows AMIs have the ExecutionPolicy set to Restricted and this breaks `kitchen converge` just before installing Chef Client because it does not allow PowerShell script execution. The added line fixes this issue.

Output:
```
$$$$$$ &amp; : File C:\Users\Administrator\AppData\Local\Temp\kitchen\default-windows-2012
$$$$$$ r2-long_script.ps1 cannot be loaded because running scripts is disabled on
$$$$$$ this system. For more information, see about_Execution_Policies at
$$$$$$ http://go.microsoft.com/fwlink/?LinkID=135170.
$$$$$$ At line:1 char:42
$$$$$$ + $ProgressPreference='SilentlyContinue';&amp;
$$$$$$ "$env:TEMP/kitchen/default-windows-2012 ...
$$$$$$ +
$$$$$$ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
$$$$$$     + CategoryInfo          : SecurityError: (:) [], PSSecurityException
>>>>>> Converge failed on instance <default-windows-2012r2>.
>>>>>> Please see .kitchen/logs/default-windows-2012r2.log for more details
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: WinRM exited (1) for command: [& "$env:TEMP/kitchen/default-windows-2012r2-long_script.ps1"]
>>>>>> ----------------------
```