### PR TITLE
Turn on eager loading for AWS resources

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -33,6 +33,8 @@ require_relative "aws/standard_platform/windows"
 require "aws-sdk-core/waiters/errors"
 require "retryable"
 
+Aws.eager_autoload!
+
 module Kitchen
 
   module Driver


### PR DESCRIPTION
See https://github.com/aws/aws-sdk-ruby/issues/833 for "why this" and https://github.com/test-kitchen/kitchen-ec2/issues/228 for the kitchen-ec2 issue.

I put this outside of the class infrastructure on the grounds that the sooner the better, but I am willing to listen to reason.

If there are performance concerns, it is possible to [reduce the scope](https://github.com/aws/aws-sdk-ruby/commit/79f8170883e71ae5183d882c2dbe1a158402cf98#diff-77ba60ac27768fbdadcae25461e31b1cR281) of this, at the cost of perhaps having concurrency bugs creep back in.