### PR TITLE
Make tags optional for clients without IAM rights to CreateTags

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -355,11 +355,13 @@ module Kitchen
       end
 
       def tag_server(server)
-        tags = []
-        config[:tags].each do |k, v|
-          tags << { :key => k, :value => v }
+        if config[:tags]
+          tags = []
+          config[:tags].each do |k, v|
+            tags << { :key => k, :value => v }
+          end
+          server.create_tags(:tags => tags)
         end
-        server.create_tags(:tags => tags)
       end
 
       # Normally we could use `server.wait_until_running` but we actually need

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -228,6 +228,10 @@ describe Kitchen::Driver::Ec2 do
       )
       driver.tag_server(server)
     end
+    it "does not raise" do
+      config[:tags] = nil
+      expect { driver.tag_server(server) }.not_to raise_error
+    end
   end
 
   describe "#wait_until_ready" do


### PR DESCRIPTION
Some EC2 users do not have the ability to CreateTags, because there are no granular controls around that (yet).  For instance, a user with CreateTags can wipe or change any tag on any resource in an account, which is not good.  This simply does not call the CreateTags API if there are no tags defined.  By default, there is a created-by tag, but if tag: is set in the config with no keys it will be nil, and the if block will not get executed.  Please merge this if it looks OK.
