### PR TITLE
In the client, only source creds from the shared file when necessary

### DIFF
--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -85,6 +85,12 @@ module Kitchen
         end
         # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
+        def self.get_shared_creds(profile_name)
+          ::Aws::SharedCredentials.new(:profile_name => profile_name)
+        rescue ::Aws::Errors::NoSuchProfileError
+          false
+        end
+
         def create_instance(options)
           resource.create_instances(options)[0]
         end
@@ -108,14 +114,6 @@ module Kitchen
 
         def resource
           @resource ||= ::Aws::EC2::Resource.new
-        end
-
-        private
-
-        def self.get_shared_creds(profile_name)
-          ::Aws::SharedCredentials.new(:profile_name => profile_name)
-        rescue ::Aws::Errors::NoSuchProfileError
-          false
         end
 
       end

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -58,19 +58,20 @@ module Kitchen
         # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
         def self.get_credentials(profile_name, access_key_id, secret_access_key, session_token,
                                  region, options = {})
-          source_creds = if access_key_id && secret_access_key
-                           ::Aws::Credentials.new(access_key_id, secret_access_key, session_token)
-                         elsif ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
-                           ::Aws::Credentials.new(
-                             ENV["AWS_ACCESS_KEY_ID"],
-                             ENV["AWS_SECRET_ACCESS_KEY"],
-                             ENV["AWS_SESSION_TOKEN"]
-                           )
-                         elsif profile_name
-                           ::Aws::SharedCredentials.new(:profile_name => profile_name)
-                         else
-                           ::Aws::InstanceProfileCredentials.new(:retries => 1)
-                         end
+          source_creds = 
+            if access_key_id && secret_access_key
+              ::Aws::Credentials.new(access_key_id, secret_access_key, session_token)
+            elsif ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
+              ::Aws::Credentials.new(
+                ENV["AWS_ACCESS_KEY_ID"],
+                ENV["AWS_SECRET_ACCESS_KEY"],
+                ENV["AWS_SESSION_TOKEN"]
+              )
+            elsif profile_name
+              ::Aws::SharedCredentials.new(:profile_name => profile_name)
+            else
+              ::Aws::InstanceProfileCredentials.new(:retries => 1)
+            end
 
           if options[:assume_role_arn] && options[:assume_role_session_name]
             sts = ::Aws::STS::Client.new(:credentials => source_creds, :region => region)

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -79,8 +79,6 @@ module Kitchen
               :role_session_name => options[:assume_role_session_name]
             )
             ::Aws::AssumeRoleCredentials.new(assume_role_options)
-          elsif profile_name
-            ::Aws::SharedCredentials.new(:profile_name => profile_name)
           else
             ::Aws::InstanceProfileCredentials.new(:retries => 1)
           end
@@ -110,6 +108,14 @@ module Kitchen
 
         def resource
           @resource ||= ::Aws::EC2::Resource.new
+        end
+
+        private
+
+        def self.get_shared_creds(profile_name)
+          ::Aws::SharedCredentials.new(:profile_name => profile_name)
+        rescue ::Aws::Errors::NoSuchProfileError
+          false
         end
 
       end

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -58,20 +58,20 @@ module Kitchen
         # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
         def self.get_credentials(profile_name, access_key_id, secret_access_key, session_token,
                                  region, options = {})
-          source_creds = 
-            if access_key_id && secret_access_key
-              ::Aws::Credentials.new(access_key_id, secret_access_key, session_token)
-            elsif ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
-              ::Aws::Credentials.new(
-                ENV["AWS_ACCESS_KEY_ID"],
-                ENV["AWS_SECRET_ACCESS_KEY"],
-                ENV["AWS_SESSION_TOKEN"]
-              )
-            elsif profile_name
-              ::Aws::SharedCredentials.new(:profile_name => profile_name)
-            else
-              ::Aws::InstanceProfileCredentials.new(:retries => 1)
-            end
+          source_creds =
+          if access_key_id && secret_access_key
+            ::Aws::Credentials.new(access_key_id, secret_access_key, session_token)
+          elsif ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
+            ::Aws::Credentials.new(
+              ENV["AWS_ACCESS_KEY_ID"],
+              ENV["AWS_SECRET_ACCESS_KEY"],
+              ENV["AWS_SESSION_TOKEN"]
+            )
+          elsif profile_name
+            ::Aws::SharedCredentials.new(:profile_name => profile_name)
+          else
+            ::Aws::InstanceProfileCredentials.new(:retries => 1)
+          end
 
           if options[:assume_role_arn] && options[:assume_role_session_name]
             sts = ::Aws::STS::Client.new(:credentials => source_creds, :region => region)

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -55,8 +55,9 @@ module Kitchen
         # Try and get the credentials from an ordered list of locations
         # http://docs.aws.amazon.com/sdkforruby/api/index.html#Configuration
         # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        def self.get_credentials(profile_name, access_key_id, secret_access_key, session_token)
-          shared_creds = ::Aws::SharedCredentials.new(:profile_name => profile_name)
+        # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
+        def self.get_credentials(profile_name, access_key_id, secret_access_key, session_token,
+                                 region, options = {})
           if access_key_id && secret_access_key
             ::Aws::Credentials.new(access_key_id, secret_access_key, session_token)
           elsif ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
@@ -65,8 +66,19 @@ module Kitchen
               ENV["AWS_SECRET_ACCESS_KEY"],
               ENV["AWS_SESSION_TOKEN"]
             )
-          elsif shared_creds.loadable?
-            shared_creds
+          elsif shared_creds = ::Aws::SharedCredentials.new(:profile_name => profile_name)
+            source_creds = shared_creds
+          else
+            source_creds = ::Aws::InstanceProfileCredentials.new(:retries => 1)
+          end
+          if options[:assume_role_arn] && options[:assume_role_session_name]
+            sts = ::Aws::STS::Client.new(:credentials => source_creds, :region => region)
+            assume_role_options = (options[:assume_role_options] || {}).merge(
+              :client => sts,
+              :role_arn => options[:assume_role_arn],
+              :role_session_name => options[:assume_role_session_name]
+            )
+            ::Aws::AssumeRoleCredentials.new(assume_role_options)
           else
             ::Aws::InstanceProfileCredentials.new(:retries => 1)
           end

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -67,7 +67,6 @@ module Kitchen
               ENV["AWS_SESSION_TOKEN"]
             )
           elsif profile_name
-            # require 'pry'; binding.pry
             source_creds = ::Aws::SharedCredentials.new(:profile_name => profile_name)
           else
             source_creds = ::Aws::InstanceProfileCredentials.new(:retries => 1)

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -42,7 +42,7 @@ module Kitchen
           retry_limit = nil
         )
           creds = self.class.get_credentials(
-            profile_name, access_key_id, secret_access_key, session_token
+            profile_name, access_key_id, secret_access_key, session_token, region
           )
           ::Aws.config.update(
             :region => region,
@@ -58,19 +58,19 @@ module Kitchen
         # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
         def self.get_credentials(profile_name, access_key_id, secret_access_key, session_token,
                                  region, options = {})
-          if access_key_id && secret_access_key
-            source_creds = ::Aws::Credentials.new(access_key_id, secret_access_key, session_token)
-          elsif ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
-            ::Aws::Credentials.new(
-              ENV["AWS_ACCESS_KEY_ID"],
-              ENV["AWS_SECRET_ACCESS_KEY"],
-              ENV["AWS_SESSION_TOKEN"]
-            )
-          elsif profile_name
-            source_creds = ::Aws::SharedCredentials.new(:profile_name => profile_name)
-          else
-            source_creds = ::Aws::InstanceProfileCredentials.new(:retries => 1)
-          end
+          source_creds = if access_key_id && secret_access_key
+                           ::Aws::Credentials.new(access_key_id, secret_access_key, session_token)
+                         elsif ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
+                           ::Aws::Credentials.new(
+                             ENV["AWS_ACCESS_KEY_ID"],
+                             ENV["AWS_SECRET_ACCESS_KEY"],
+                             ENV["AWS_SESSION_TOKEN"]
+                           )
+                         elsif profile_name
+                           ::Aws::SharedCredentials.new(:profile_name => profile_name)
+                         else
+                           ::Aws::InstanceProfileCredentials.new(:retries => 1)
+                         end
 
           if options[:assume_role_arn] && options[:assume_role_session_name]
             sts = ::Aws::STS::Client.new(:credentials => source_creds, :region => region)
@@ -83,7 +83,7 @@ module Kitchen
 
             ::Aws::AssumeRoleCredentials.new(assume_role_options)
           else
-            ::Aws::InstanceProfileCredentials.new(:retries => 1)
+            source_creds
           end
         end
         # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -79,6 +79,8 @@ module Kitchen
               :role_session_name => options[:assume_role_session_name]
             )
             ::Aws::AssumeRoleCredentials.new(assume_role_options)
+          elsif profile_name
+            ::Aws::SharedCredentials.new(:profile_name => profile_name)
           else
             ::Aws::InstanceProfileCredentials.new(:retries => 1)
           end

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -25,6 +25,7 @@ describe Kitchen::Driver::Aws::Client do
     it "loads IAM credentials last" do
       iam = instance_double(Aws::InstanceProfileCredentials)
 
+      allow(Kitchen::Driver::Aws::Client).to receive(:get_shared_creds).and_return(false)
       allow(Aws::InstanceProfileCredentials).to receive(:new).and_return(iam)
 
       env_creds(nil, nil) do

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -46,7 +46,7 @@ describe Kitchen::Driver::Aws::Client do
 
     it "loads credentials from the environment third to last" do
       env_creds("key_id", "secret") do
-        expect(Kitchen::Driver::Aws::Client.get_credentials("profile", nil, nil, nil, nil)).to \
+        expect(Kitchen::Driver::Aws::Client.get_credentials(nil, nil, nil, nil, nil)).to \
           be_a(Aws::Credentials).and have_attributes(
             :access_key_id => "key_id",
             :secret_access_key => "secret"

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -26,7 +26,7 @@ describe Kitchen::Driver::Aws::Client do
 
     # nothing else is set, so we default to this
     it "loads IAM credentials last" do
-      env_creds(nil, nil) do 
+      env_creds(nil, nil) do
         expect(::Aws::SharedCredentials).to receive(:new).and_return(false)
         expect(Aws::InstanceProfileCredentials).to receive(:new).and_return(iam)
         expect(Kitchen::Driver::Aws::Client.get_credentials("profile", nil, nil, nil)).to eq(iam)
@@ -34,7 +34,7 @@ describe Kitchen::Driver::Aws::Client do
     end
 
     it "loads shared credentials second to last" do
-      env_creds(nil, nil) do 
+      env_creds(nil, nil) do
         expect(Aws::SharedCredentials).to \
           receive(:new).with(:profile_name => "profile").and_return(shared)
         expect(Kitchen::Driver::Aws::Client.get_credentials("profile", nil, nil, nil)).to eq(shared)
@@ -118,11 +118,11 @@ describe Kitchen::Driver::Aws::Client do
     expect(client.resource).to be_a(Aws::EC2::Resource)
   end
 
-  def env_creds(key_id, secret, &block) 
+  def env_creds(key_id, secret, &block)
     ClimateControl.modify(
       "AWS_ACCESS_KEY_ID" => key_id,
-      "AWS_SECRET_ACCESS_KEY" => secret,
-    ) do 
+      "AWS_SECRET_ACCESS_KEY" => secret
+    ) do
       block.call
     end
   end

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -40,7 +40,8 @@ describe Kitchen::Driver::Aws::Client do
         receive(:new).with(:profile_name => "profile").and_return(shared)
 
       env_creds(nil, nil) do
-        expect(Kitchen::Driver::Aws::Client.get_credentials("profile", nil, nil, nil, nil)).to eq(shared)
+        expect(Kitchen::Driver::Aws::Client.get_credentials("profile", nil, nil, nil, nil)).to \
+          eq(shared)
       end
     end
 
@@ -118,7 +119,8 @@ describe Kitchen::Driver::Aws::Client do
     end
 
     it "loads shared credentials second to last" do
-      expect(::Aws::SharedCredentials).to receive(:new).with(profile_name: "profile").and_return(shared)
+      expect(::Aws::SharedCredentials).to \
+        receive(:new).with(:profile_name => "profile").and_return(shared)
       expect(Aws::STS::Client).to \
         receive(:new).with(:credentials => shared, :region => "us-west-1").and_return(sts_client)
 

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -22,17 +22,12 @@ require "climate_control"
 describe Kitchen::Driver::Aws::Client do
   describe "::get_credentials" do
     let(:shared) { instance_double(Aws::SharedCredentials) }
-    let(:iam) { instance_double(Aws::InstanceProfileCredentials) }
-
-    before do
-      expect(Aws::SharedCredentials).to \
-        receive(:new).with(:profile_name => "profile").and_return(shared)
-    end
+    let(:iam)    { instance_double(Aws::InstanceProfileCredentials) }
 
     # nothing else is set, so we default to this
     it "loads IAM credentials last" do
       env_creds(nil, nil) do 
-        expect(shared).to receive(:loadable?).and_return(false)
+        expect(::Aws::SharedCredentials).to receive(:new).and_return(false)
         expect(Aws::InstanceProfileCredentials).to receive(:new).and_return(iam)
         expect(Kitchen::Driver::Aws::Client.get_credentials("profile", nil, nil, nil)).to eq(iam)
       end
@@ -40,7 +35,8 @@ describe Kitchen::Driver::Aws::Client do
 
     it "loads shared credentials second to last" do
       env_creds(nil, nil) do 
-        expect(shared).to receive(:loadable?).and_return(true)
+        expect(Aws::SharedCredentials).to \
+          receive(:new).with(:profile_name => "profile").and_return(shared)
         expect(Kitchen::Driver::Aws::Client.get_credentials("profile", nil, nil, nil)).to eq(shared)
       end
     end


### PR DESCRIPTION
Note: the first 2 commits in this PR represent changes that I had to make in order to get the test suite to run on my machine. Several specs seem to assume that there aren't any AWS credentials set as environment variables on the developer's machine. 

The last commit is re: #258 and improves the logic related to how the client sources its AWS credentials.
