### PR TITLE
Fix autoload race in Aws::EC2::*

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "test-kitchen"
 gem "winrm-transport"
 gem "winrm-fs"
+gem "activesupport", "~> 4.0"
 
 group :test do
   gem "rake"

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -82,6 +82,13 @@ module Kitchen
 
       required_config :aws_ssh_key_id
 
+      def initialize(*args, &block)
+        super
+        # Access these so they are eagerly loaded (since we'll reference them later)
+        ::Aws::EC2::Client # rubocop:disable Lint/Void
+        ::Aws::EC2::Resource # rubocop:disable Lint/Void
+      end
+
       def self.validation_warn(driver, old_key, new_key)
         driver.warn "WARN: The driver[#{driver.class.name}] config key `#{old_key}` " \
           "is deprecated, please use `#{new_key}`"


### PR DESCRIPTION
by accessing the resources we need in driver initialize.

Tests for this are hard to write because they have to run separately. Here is the test I ran:

```
require "kitchen/driver/ec2"

ec2 = Kitchen::Driver::Ec2.new({})
threads = (1..1000).map do
  Thread.new do
    begin
      ec2.ec2.resource
    rescue
      STDERR.puts "Noooo #{$!}"
    end
  end
end
threads.each { |t| t.join }
```

If I run this *before* my patch, it prints out "Nooooo uninitialized constant Aws::EC2::Resource" multiple times. After the patch, it doesn't print it out.