### PR TITLE
pin rack to ~> 1.0

### DIFF
--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -38,4 +38,8 @@ Gem::Specification.new do |gem|
   # enforced in CI
   gem.add_development_dependency "finstyle",  "1.4.0"
   gem.add_development_dependency "climate_control"
+
+  # github_changelog_generator -> github-api -> oauth2 -> rack
+  # rack being unconstrained breaks Ruby 2.1 installs
+  gem.add_development_dependency "rack", "~> 1.0"
 end


### PR DESCRIPTION
Prevent build breaks on lower ruby.