### PR TITLE
Don't break if we're using a custom "platform" AMI

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -287,9 +287,14 @@ module Kitchen
       end
 
       def update_username(state)
-        # TODO: if the user explicitly specified the transport's default username,
-        # do NOT overwrite it!
-        if instance.transport[:username] == instance.transport.class.defaults[:username]
+        # BUG: With the following equality condition on username, if the user specifies 'root'
+        # as the transport's username then we will overwrite that value with one from the standard
+        # platform definitions.  This seems difficult to handle here as the default username is
+        # provided by the underlying transport classes, and is often non-nil (eg; 'root'), leaving
+        # us no way to distinguish a user-set value from the transport's default.
+        # See https://github.com/test-kitchen/kitchen-ec2/pull/273
+        if actual_platform &&
+            instance.transport[:username] == instance.transport.class.defaults[:username]
           debug("No SSH username specified: using default username #{actual_platform.username} " \
                 " for image #{config[:image_id]}, which we detected as #{actual_platform}.")
           state[:username] = actual_platform.username

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -382,6 +382,18 @@ describe Kitchen::Driver::Ec2 do
       include_examples "common create"
     end
 
+    context "instance is not a standard platform" do
+      let(:state) { {} }
+      before do
+        expect(driver).to receive(:actual_platform).and_return(nil)
+      end
+
+      it "doesn't set the state username" do
+        driver.update_username(state)
+        expect(state).to eq({})
+      end
+    end
+
   end
 
   describe "#destroy" do


### PR DESCRIPTION
If i'm using an private image_id whose AMI Name doesn't match one of the "standard_platform"s (ie; "oel-7.2"), i can't seem to override the username.  Instead, i get the following error:

```
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [undefined method `username' for nil:NilClass] on default-oel-72
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

which - i think - is because [actual_platform](https://github.com/test-kitchen/kitchen-ec2/blob/119001d1ad2e7879151ed62aa76588ac49017725/lib/kitchen/driver/ec2.rb#L266) doesn't get populated, so [update_username](https://github.com/test-kitchen/kitchen-ec2/blob/119001d1ad2e7879151ed62aa76588ac49017725/lib/kitchen/driver/ec2.rb#L295) which relies on it fails?

Possibly the same thing that @gretel's comment refers to [here](https://github.com/test-kitchen/kitchen-ec2/issues/225#issuecomment-199296835)

This PR works around it by not attempting to do anything with the username if actual_platform isn't defined (and therefore assumes you're setting the `transport.username` yourself).
