### PR TITLE
Add optional config for shutdown_behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,12 @@ The price you bid in order to submit a spot request. An additional step will be 
 
 The default is `nil`.
 
+### `instance_initiated_shutdown_behavior`
+
+Control whether an instance should `stop` or `terminate` when shutdown is initiated from the instance using an operating system command for system shutdown.
+
+The default is `nil`.
+
 ### block_duration_minutes
 
 The [specified duration](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#fixed-duration-spot-instances) for a spot instance, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -84,6 +84,10 @@ module Kitchen
               i[:network_interfaces][0][:groups] = i.delete(:security_group_ids)
             end
           end
+          unless config[:instance_initiated_shutdown_behavior].nil? ||
+              config[:instance_initiated_shutdown_behavior].empty?
+            i[:instance_initiated_shutdown_behavior] = config[:instance_initiated_shutdown_behavior]
+          end
           i
         end
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -79,6 +79,7 @@ module Kitchen
       default_config :interface,           nil
       default_config :http_proxy,          ENV["HTTPS_PROXY"] || ENV["HTTP_PROXY"]
       default_config :retry_limit,         3
+      default_config :instance_initiated_shutdown_behavior, nil
 
       def initialize(*args, &block)
         super
@@ -153,6 +154,12 @@ module Kitchen
           raise "#{attr} is no longer valid, please use " \
             "ENV['AWS_SESSION_TOKEN'] or ~/.aws/credentials.  See " \
             "the README for more details"
+        end
+      end
+      validations[:instance_initiated_shutdown_behavior] = lambda do |attr, val, _driver|
+        unless [nil, "stop", "terminate"].include?(val)
+          raise "'#{val}' is an invalid value for option '#{attr}'. " \
+            "Valid values are 'stop' or 'terminate'"
         end
       end
 

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -187,6 +187,23 @@ describe Kitchen::Driver::Ec2 do
     end
   end
 
+  describe "submit_server with terminate shutdown behaviour" do
+    before do
+      config[:instance_initiated_shutdown_behavior] = "terminate"
+      expect(driver).to receive(:instance).at_least(:once).and_return(instance)
+    end
+
+    it "submits the server request" do
+      expect(generator).to receive(:ec2_instance_data).and_return(
+        :instance_initiated_shutdown_behavior => "terminate"
+      )
+      expect(client).to receive(:create_instance).with(
+        :min_count => 1, :max_count => 1, :instance_initiated_shutdown_behavior => "terminate"
+      )
+      driver.submit_server
+    end
+  end
+
   describe "#submit_spot" do
     let(:state) { {} }
     let(:response) {


### PR DESCRIPTION
This PR allows users to change the default [shutdown behavior](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) of ec2 instances.

Example use-case: 
* Allow an instance to self-terminate if running for more than N hours.