### PR TITLE
Add expiration to spot requests

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -356,9 +356,11 @@ module Kitchen
       end
 
       def create_spot_request
+        request_duration = config[:retryable_tries] * config[:retryable_sleep]
         request_data = {
           :spot_price => config[:spot_price].to_s,
-          :launch_specification => instance_generator.ec2_instance_data
+          :launch_specification => instance_generator.ec2_instance_data,
+          :valid_until => Time.now + request_duration
         }
         if config[:block_duration_minutes]
           request_data[:block_duration_minutes] = config[:block_duration_minutes]

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -212,12 +212,16 @@ describe Kitchen::Driver::Ec2 do
 
     before do
       expect(driver).to receive(:instance).at_least(:once).and_return(instance)
+      allow(Time).to receive(:now).and_return(Time.now)
     end
 
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
       expect(actual_client).to receive(:request_spot_instances).with(
-        :spot_price => "", :launch_specification => {}, :block_duration_minutes => 60
+        :spot_price => "",
+        :launch_specification => {},
+        :valid_until => Time.now + (config[:retryable_tries] * config[:retryable_sleep]),
+        :block_duration_minutes => 60
       ).and_return(response)
       expect(actual_client).to receive(:wait_until)
       expect(client).to receive(:get_instance_from_spot_request).with("id")


### PR DESCRIPTION
Currently, if a `kitchen converge` times out then the spot request does not get cleaned up. This means an operator has to manually remove the spot requests, leaving an opening for extra costs that are unnecessary and difficult to track down. 

It seems to me that we'd want the spot request to expire if it hasn't been fulfilled within the timeframe of `config[:retryable_tries] * config[:retryable_sleep]` seconds, so it would make sense to set an expiry on the request as such.