### PR TITLE
modernize winrm setup and fix for 2008r2

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -567,13 +567,15 @@ module Kitchen
         # Allow script execution
         Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force
         #PS Remoting and & winrm.cmd basic config
-        Enable-PSRemoting -Force -SkipNetworkProfileCheck
+        $enableArgs=@{Force=$true}
+        $command=Get-Command Enable-PSRemoting
+        if($command.Parameters.Keys -contains "skipnetworkprofilecheck"){
+            $enableArgs.skipnetworkprofilecheck=$true
+        }
+        Enable-PSRemoting @enableArgs
         & winrm.cmd set winrm/config '@{MaxTimeoutms="1800000"}' >> $logfile
         & winrm.cmd set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}' >> $logfile
         & winrm.cmd set winrm/config/winrs '@{MaxShellsPerUser="50"}' >> $logfile
-        #Server settings - support username/password login
-        & winrm.cmd set winrm/config/service/auth '@{Basic="true"}' >> $logfile
-        & winrm.cmd set winrm/config/service '@{AllowUnencrypted="true"}' >> $logfile
         & winrm.cmd set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}' >> $logfile
         #Firewall Config
         & netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" profile=public protocol=tcp localport=5985 remoteip=localsubnet new remoteip=any  >> $logfile


### PR DESCRIPTION
The default `user_data` is broken on 2008R2. It currently runs:

```
Enable-PSRemoting -Force -SkipNetworkProfileCheck
```

The `SkipNetworkProfileCheck` argument is not available on powershell versions prior to 3.0. Windows 2008R2 ships with 2.0 by default. On 2008R2, this command returns:

```
PS C:\Users\Administrator> Enable-PSRemoting -Force -SkipNetworkProfileCheck
Enable-PSRemoting : A parameter cannot be found that matches parameter name 'SkipNetworkProfileCheck'.
At line:1 char:50
+ Enable-PSRemoting -Force -SkipNetworkProfileCheck <<<<
    + CategoryInfo          : InvalidArgument: (:) [Enable-PSRemoting], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.PowerShell.Commands.EnablePSRemotingCommand
```

This PR also removes the insecure configuration settings of allowing basic auth and  unencrypted traffic. The winrm gem has been using NTLM auth by default for over a year and these settings are no longer necessary and unwanted.

fixes #303 

Signed-off-by: Matt Wrock <matt@mattwrock.com>