### PR TITLE
Add support for Debian Stretch

### DIFF
--- a/lib/kitchen/driver/aws/standard_platform/debian.rb
+++ b/lib/kitchen/driver/aws/standard_platform/debian.rb
@@ -9,6 +9,7 @@ module Kitchen
           StandardPlatform.platforms["debian"] = self
 
           DEBIAN_CODENAMES = {
+            "9" => "stretch",
             "8" => "jessie",
             "7" => "wheezy",
             "6" => "squeeze",

--- a/spec/kitchen/driver/ec2/image_selection_spec.rb
+++ b/spec/kitchen/driver/ec2/image_selection_spec.rb
@@ -93,7 +93,11 @@ describe "Default images for various platforms" do
 
     "debian" => [
       { :name => "owner-id", :values => %w{379101102735} },
-      { :name => "name", :values => %w{debian-jessie-*} },
+      { :name => "name", :values => %w{debian-stretch-*} },
+    ],
+    "debian-9" => [
+      { :name => "owner-id", :values => %w{379101102735} },
+      { :name => "name", :values => %w{debian-stretch-*} },
     ],
     "debian-8" => [
       { :name => "owner-id", :values => %w{379101102735} },
@@ -109,7 +113,7 @@ describe "Default images for various platforms" do
     ],
     "debian-x86_64" => [
       { :name => "owner-id", :values => %w{379101102735} },
-      { :name => "name", :values => %w{debian-jessie-*} },
+      { :name => "name", :values => %w{debian-stretch-*} },
       { :name => "architecture", :values => %w{x86_64} },
     ],
     "debian-6-x86_64" => [


### PR DESCRIPTION
That's it. Nothing special. Confirmed that I can `kitchen test` the
`debian-9` platform with this applied.

Signed-off-by: Jonathan Hartman <j@p4nt5.com>