### PR TITLE
Pass named profile to Aws::Config directly

### DIFF
--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -42,15 +42,22 @@ module Kitchen
           retry_limit = nil,
           ssl_verify_peer = true
         )
-          creds = self.class.get_credentials(
-            profile_name, access_key_id, secret_access_key, session_token, region
-          )
+
           ::Aws.config.update(
             :region => region,
-            :credentials => creds,
             :http_proxy => http_proxy,
             :ssl_verify_peer => ssl_verify_peer
           )
+
+          if profile_name
+            ::Aws.config.update(profile: profile_name)
+          else
+            creds = self.class.get_credentials(
+              profile_name, access_key_id, secret_access_key, session_token, region
+            )
+            ::Aws.config.update(credentials: creds)
+          end
+
           ::Aws.config.update(:retry_limit => retry_limit) unless retry_limit.nil?
         end
 

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -163,11 +163,11 @@ describe Kitchen::Driver::Aws::Client do
       expect(Aws.config[:region]).to eq("us-west-1")
     end
 
-    context "when provided all optional parameters" do
+    context "when not provided profile_name" do
       let(:client) do
         Kitchen::Driver::Aws::Client.new(
           "us-west-1",
-          "profile_name",
+          nil,
           "access_key_id",
           "secret_access_key",
           "session_token",
@@ -182,6 +182,29 @@ describe Kitchen::Driver::Aws::Client do
         client
         expect(Aws.config[:region]).to eq("us-west-1")
         expect(Aws.config[:credentials]).to eq(creds)
+        expect(Aws.config[:http_proxy]).to eq("http_proxy")
+        expect(Aws.config[:retry_limit]).to eq(999)
+        expect(Aws.config[:ssl_verify_peer]).to eq(false)
+      end
+    end
+
+    context "when provided profile_name" do
+      let(:client) do
+        Kitchen::Driver::Aws::Client.new(
+          "us-west-1",
+          "my_profile",
+          "access_key_id",
+          "secret_access_key",
+          "session_token",
+          "http_proxy",
+          999,
+          false
+        )
+      end
+      it "Sets the AWS config" do
+        client
+        expect(Aws.config[:region]).to eq("us-west-1")
+        expect(Aws.config[:profile]).to eq("my_profile")
         expect(Aws.config[:http_proxy]).to eq("http_proxy")
         expect(Aws.config[:retry_limit]).to eq(999)
         expect(Aws.config[:ssl_verify_peer]).to eq(false)


### PR DESCRIPTION
Kitchen-ec2 should allow aws-sdk to decide best credentials when passed a properly configured profile.

Aws::SharedCredentials does not negotiate some profile features that are available.  (some attempts to patch the module in the aws-sdk-ruby repo have gone stale)

Example (assume role):
```
[auth]
aws_access_key_id=foobar
aws_secret_access_key=foobarbaz

[use1dev]
source_profile = auth
region = us-east-1
role_arn = arn:aws:iam::12345678910:role/auth-admin
```

I'm proposing to pass the profile directly to the config/client when user-specified, rather than passing it through SharedCredentials, which does not support some credentials file functionality.

Edit:  Specifically this brings kitchen-ec2 in line with aws-cli functionality described here http://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html  