### PR TITLE
Handle nulls/binary text in user data so it supports gzip

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -154,14 +154,14 @@ module Kitchen
         def prepared_user_data
           # If user_data is a file reference, lets read it as such
           return nil if config[:user_data].nil?
-          @user_data ||= begin
-            if File.file?(config[:user_data])
-              @user_data = File.read(config[:user_data])
-            else
-              @user_data = config[:user_data]
-            end
-            @user_data = Base64.encode64(@user_data)
+          return @user_data if @user_data
+
+          raw_user_data = config.fetch(:user_data)
+          if !raw_user_data.include?("\0") && File.file?(raw_user_data)
+            raw_user_data = File.read(raw_user_data)
           end
+
+          @user_data = Base64.encode64(raw_user_data)
         end
 
       end

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -61,7 +61,7 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when config[:user_data] is binary" do
       let(:config) { { :user_data => "foo\0bar" } }
 
-      it 'handles nulls in user_data' do
+      it "handles nulls in user_data" do
         expect(Base64.decode64(generator.prepared_user_data)).to eq "foo\0bar"
       end
     end

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -57,6 +57,14 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
         expect(decoded).to eq("foo\nbar")
       end
     end
+
+    context "when config[:user_data] is binary" do
+      let(:config) { { :user_data => "foo\0bar" } }
+
+      it 'handles nulls in user_data' do
+        expect(Base64.decode64(generator.prepared_user_data)).to eq "foo\0bar"
+      end
+    end
   end
 
   describe "#ec2_instance_data" do


### PR DESCRIPTION
`File.file?("\0")` raises ArgumentError, so it was previously impossible
to set binary data (such as gzipped data) in EC2 user_data.

This PR also adds a test that would have caught the bug.