### PR TITLE
Update AWS-SDK to v3

### DIFF
--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "test-kitchen", "~> 1.4", ">= 1.4.1"
   gem.add_dependency "excon"
   gem.add_dependency "multi_json"
-  gem.add_dependency "aws-sdk", "~> 2"
+  gem.add_dependency "aws-sdk-ec2", "~> 1.42"
   gem.add_dependency "retryable", "~> 2.0"
 
   gem.add_development_dependency "rspec",     "~> 3.2"

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "aws-sdk"
+require "aws-sdk-ec2"
 require "aws-sdk-core/credentials"
 require "aws-sdk-core/shared_credentials"
 require "aws-sdk-core/instance_profile_credentials"
@@ -50,7 +50,7 @@ module Kitchen
         end
 
         def create_instance(options)
-          resource.create_instances(options)[0]
+          resource.create_instances(options).first
         end
 
         def get_instance(id)

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 require "base64"
-require "aws-sdk"
+require "aws-sdk-ec2"
 
 module Kitchen
 

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -21,7 +21,7 @@ require "kitchen/driver/aws/instance_generator"
 require "kitchen/driver/aws/client"
 require "tempfile"
 require "base64"
-require "aws-sdk"
+require "aws-sdk-ec2"
 
 describe Kitchen::Driver::Aws::InstanceGenerator do
 

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -277,8 +277,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { :key1 => "value1", :key2 => "value2" }
         expect(server).to receive(:create_tags).with(
           :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "value2" },
+            { :key => "key1", :value => "value1" },
+            { :key => "key2", :value => "value2" },
           ]
         )
         driver.tag_server(server)
@@ -290,8 +290,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { :key1 => "value1", :key2 => 1 }
         expect(server).to receive(:create_tags).with(
           :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "1" },
+            { :key => "key1", :value => "value1" },
+            { :key => "key2", :value => "1" },
           ]
         )
         driver.tag_server(server)
@@ -303,8 +303,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { :key1 => "value1", :key2 => nil }
         expect(server).to receive(:create_tags).with(
           :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "" },
+            { :key => "key1", :value => "value1" },
+            { :key => "key2", :value => "" },
           ]
         )
         driver.tag_server(server)
@@ -322,8 +322,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { :key1 => "value1", :key2 => "value2" }
         expect(volume).to receive(:create_tags).with(
           :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "value2" },
+            { :key => "key1", :value => "value1" },
+            { :key => "key2", :value => "value2" },
           ]
         )
         driver.tag_volumes(server)
@@ -335,8 +335,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { :key1 => "value1", :key2 => 2 }
         expect(volume).to receive(:create_tags).with(
           :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "2" },
+            { :key => "key1", :value => "value1" },
+            { :key => "key2", :value => "2" },
           ]
         )
         driver.tag_volumes(server)
@@ -348,8 +348,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { :key1 => "value1", :key2 => nil }
         expect(volume).to receive(:create_tags).with(
           :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "" },
+            { :key => "key1", :value => "value1" },
+            { :key => "key2", :value => "" },
           ]
         )
         driver.tag_volumes(server)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,6 +102,6 @@ RSpec.configure do |config|
 
 end
 
-require "aws-sdk"
+require "aws-sdk-ec2"
 # https://ruby.awsblog.com/post/Tx15V81MLPR8D73/Client-Response-Stubs
 Aws.config[:stub_responses] = true


### PR DESCRIPTION
This PR updates the Gem to use the aws-sdk-iam and aws-sdk-ec2 gems rather than load the whole SDK.