### PR TITLE
Add EC2 hostname when printing ready message

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -221,7 +221,7 @@ module Kitchen
           fetch_windows_admin_password(server, state)
         end
 
-        info("EC2 instance <#{state[:server_id]}> ready.")
+        info("EC2 instance <#{state[:server_id]}> ready (hostname: #{state[:hostname]}).")
         instance.transport.connection(state).wait_until_ready
         create_ec2_json(state)
         debug("ec2:create '#{state[:hostname]}'")


### PR DESCRIPTION
When SSH connectivity is immediately available, kitchen-ec2 never prints
the hostname of the instance, leading to do `ss` or things like that
to retrieve the IP and start to remotely connect services.