### PR TITLE
Set LocalAccountTokenFilterPolicy to allow powershell remoting from local accounts

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -579,6 +579,7 @@ module Kitchen
         & winrm.cmd set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}' >> $logfile
         #Firewall Config
         & netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" profile=public protocol=tcp localport=5985 remoteip=localsubnet new remoteip=any  >> $logfile
+        Set-ItemProperty -Name LocalAccountTokenFilterPolicy -Path HKLM:\\software\\Microsoft\\Windows\\CurrentVersion\\Policies\\system -Value 1
         #{custom_admin_script}
         </powershell>
         EOH


### PR DESCRIPTION
LocalAccountTokenFilterPolicy **should** be set by `Enable-PSRemoting`, but doesn't seem to be on 2016. 
I had issues similar to those presented in #319 and #331, this will should fix both.