### PR TITLE
Clean up original Authentication; Rely on SDK for Chain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,35 +147,18 @@ follow the other `image_search` rules for preference.
 
 ### AWS Authentication
 
-In order to connect to AWS, you must specify the AWS access key id and secret key
-for your account. There are 3 ways you do this, and we will try them in the
-following order:
+In order to connect to AWS, you must specify AWS credentials. We rely on the SDK
+to find credentials in the standard way, documented here: 
+https://github.com/aws/aws-sdk-ruby/#configuration
 
-1. You can specify the access key and access secret (and optionally the session
-   token) through config.  See the `aws_access_key_id` and `aws_secret_access_key`
-   config sections below to see how to specify these in your .kitchen.yml or
-   through environment variables.  If you would like to specify your session token
-   use the environment variable `AWS_SESSION_TOKEN`.
-2. The shared credentials ini file at `~/.aws/credentials`. This is the file
-   populated by `aws configure` command line and used by AWS tools in general, so if
-   you are set up for any other AWS tools, you probably already have this. You can
-   specify multiple profiles in this file and select one with the `AWS_PROFILE`
-   environment variable or the `shared_credentials_profile` driver config.  Read
-   [this][credentials_docs] for more information.
-3. From an instance profile when running on EC2.  This accesses the local
-   metadata service to discover the local instance's IAM instance profile.
-
-This precedence order is taken from http://docs.aws.amazon.com/sdkforruby/api/index.html#Configuration
-
-The first method attempted that works will be used.  IE, if you want to auth
-using the instance profile, you must not set any of the access key configs
-or environment variables, and you must not specify a `~/.aws/credentials`
-file.
+The SDK Chain will search environment variables, then config files, then IAM role
+data from the instance profile, in that order. In the case config files being 
+present, the 'default' profile will be used unless `shared_credentials_profile` 
+is defined to point to another profile. 
 
 Because the Test Kitchen test should be checked into source control and ran
 through CI we no longer recommend storing the AWS credentials in the
-`.kitchen.yml` file.  Instead, specify them as environment variables or in the
-`~/.aws/credentials` file.
+`.kitchen.yml` file.
 
 ### Instance Login Configuration
 

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -20,135 +20,6 @@ require "kitchen/driver/aws/client"
 require "climate_control"
 
 describe Kitchen::Driver::Aws::Client do
-  describe "::get_credentials" do
-    # nothing else is set, so we default to this
-    it "loads IAM credentials last" do
-      iam = instance_double(Aws::InstanceProfileCredentials)
-
-      allow(Kitchen::Driver::Aws::Client).to receive(:default_shared_credentials?).and_return(false)
-      allow(Aws::InstanceProfileCredentials).to receive(:new).and_return(iam)
-
-      env_creds(nil, nil) do
-        expect(Kitchen::Driver::Aws::Client.get_credentials(nil, nil, nil, nil, nil)).to eq(iam)
-      end
-    end
-
-    it "loads the default shared creds profile second to last" do
-      shared = instance_double(Aws::SharedCredentials)
-
-      allow(Kitchen::Driver::Aws::Client).to receive(:default_shared_credentials?).and_return(true)
-      allow(Aws::SharedCredentials).to \
-        receive(:new).and_return(shared)
-
-      env_creds(nil, nil) do
-        expect(Kitchen::Driver::Aws::Client.get_credentials(nil, nil, nil, nil, nil)).to \
-          eq(shared)
-      end
-    end
-
-    it "loads a custom shared credentials profile third to last" do
-      shared = instance_double(Aws::SharedCredentials)
-
-      allow(Aws::SharedCredentials).to \
-        receive(:new).with(:profile_name => "profile").and_return(shared)
-
-      env_creds(nil, nil) do
-        expect(Kitchen::Driver::Aws::Client.get_credentials("profile", nil, nil, nil, nil)).to \
-          eq(shared)
-      end
-    end
-
-    it "loads credentials from the environment third to last" do
-      env_creds("key_id", "secret") do
-        expect(Kitchen::Driver::Aws::Client.get_credentials(nil, nil, nil, nil, nil)).to \
-          be_a(Aws::Credentials).and have_attributes(
-            :access_key_id => "key_id",
-            :secret_access_key => "secret"
-          )
-      end
-    end
-
-    it "loads provided credentials first" do
-      expect(Kitchen::Driver::Aws::Client.get_credentials(
-        "profile",
-        "key3",
-        "value3",
-        nil,
-        "us-west-1"
-      )).to \
-        be_a(Aws::Credentials).and have_attributes(
-         :access_key_id => "key3",
-         :secret_access_key => "value3",
-         :session_token => nil
-       )
-    end
-
-    it "uses a session token if provided" do
-      expect(Kitchen::Driver::Aws::Client.get_credentials(
-        "profile",
-        "key3",
-        "value3",
-        "t",
-        "us-west-1"
-      )).to \
-        be_a(Aws::Credentials).and have_attributes(
-         :access_key_id => "key3",
-         :secret_access_key => "value3",
-         :session_token => "t"
-       )
-    end
-  end
-
-  describe "::get_credentials + STS AssumeRole" do
-    let(:shared) { instance_double(Aws::SharedCredentials) }
-    let(:iam) { instance_double(Aws::InstanceProfileCredentials) }
-    let(:assume_role) { instance_double(Aws::AssumeRoleCredentials) }
-    let(:sts_client) { instance_double(Aws::STS::Client) }
-
-    before do
-      expect(Aws::AssumeRoleCredentials).to \
-        receive(:new).with(
-          :client => sts_client,
-          :role_arn => "role_arn",
-          :role_session_name => "role_session_name"
-        ).and_return(assume_role)
-    end
-
-    # nothing else is set, so we default to this
-    it "loads an Instance Profile last" do
-      allow(Kitchen::Driver::Aws::Client).to receive(:default_shared_credentials?).and_return(false)
-
-      expect(Aws::InstanceProfileCredentials).to \
-        receive(:new).and_return(iam)
-      expect(Aws::STS::Client).to \
-        receive(:new).with(:credentials => iam, :region => "us-west-1").and_return(sts_client)
-
-      expect(Kitchen::Driver::Aws::Client.get_credentials(
-        nil,
-        nil,
-        nil,
-        nil,
-        "us-west-1",
-        :assume_role_arn => "role_arn", :assume_role_session_name => "role_session_name"
-      )).to eq(assume_role)
-    end
-
-    it "loads shared credentials second to last" do
-      expect(::Aws::SharedCredentials).to \
-        receive(:new).with(:profile_name => "profile").and_return(shared)
-      expect(Aws::STS::Client).to \
-        receive(:new).with(:credentials => shared, :region => "us-west-1").and_return(sts_client)
-
-      expect(Kitchen::Driver::Aws::Client.get_credentials(
-        "profile",
-        nil,
-        nil,
-        nil,
-        "us-west-1",
-        :assume_role_arn => "role_arn", :assume_role_session_name => "role_session_name"
-      )).to eq(assume_role)
-    end
-  end
 
   let(:client) { Kitchen::Driver::Aws::Client.new("us-west-1") }
 
@@ -167,7 +38,7 @@ describe Kitchen::Driver::Aws::Client do
       let(:client) do
         Kitchen::Driver::Aws::Client.new(
           "us-west-1",
-          "profile_name",
+          "test-profile",
           "access_key_id",
           "secret_access_key",
           "session_token",
@@ -176,12 +47,10 @@ describe Kitchen::Driver::Aws::Client do
           false
         )
       end
-      let(:creds) { double("creds") }
       it "Sets the AWS config" do
-        expect(Kitchen::Driver::Aws::Client).to receive(:get_credentials).and_return(creds)
         client
         expect(Aws.config[:region]).to eq("us-west-1")
-        expect(Aws.config[:credentials]).to eq(creds)
+        expect(Aws.config[:profile]).to eq("test-profile")
         expect(Aws.config[:http_proxy]).to eq("http_proxy")
         expect(Aws.config[:retry_limit]).to eq(999)
         expect(Aws.config[:ssl_verify_peer]).to eq(false)
@@ -195,14 +64,5 @@ describe Kitchen::Driver::Aws::Client do
 
   it "returns a resource" do
     expect(client.resource).to be_a(Aws::EC2::Resource)
-  end
-
-  def env_creds(key_id, secret, &block)
-    ClimateControl.modify(
-      "AWS_ACCESS_KEY_ID" => key_id,
-      "AWS_SECRET_ACCESS_KEY" => secret
-    ) do
-      yield
-    end
   end
 end


### PR DESCRIPTION
This PR removes the logic for searching for authentication credentials in favor of just relying on the SDK to find credentials through the standard means. This is necessary to allow role delegation using source_profile configurations for credentials. None of the authentication classes the SDK provides will support that, but if you let the SDK just do all the work to find the credentials, everything just works. This also greatly simplifies the logic within the kitchen-ec2 client wrapper.

I suspect this will break most/all of the tests in client_spec.rb because everything it tests is gone. I vote for just removing it, and passing the buck to the SDK for both finding, and testing all the various methods, of credential finding. I didn't remove the tests in this PR yet, pending discussion on that point.