### PR TITLE
Automatically create a security group and key pair if needed.

### DIFF
--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -35,9 +35,6 @@ module Kitchen
         def initialize( # rubocop:disable Metrics/ParameterLists
           region,
           profile_name = "default",
-          access_key_id = nil,
-          secret_access_key = nil,
-          session_token = nil,
           http_proxy = nil,
           retry_limit = nil,
           ssl_verify_peer = true

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -34,6 +34,8 @@ require_relative "aws/standard_platform/windows"
 require "aws-sdk-core/waiters/errors"
 require "retryable"
 require "time"
+require "etc"
+require "socket"
 
 Aws.eager_autoload!
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -329,9 +329,6 @@ module Kitchen
         @ec2 ||= Aws::Client.new(
           config[:region],
           config[:shared_credentials_profile],
-          config[:aws_access_key_id],
-          config[:aws_secret_access_key],
-          config[:aws_session_token],
           config[:http_proxy],
           config[:retry_limit],
           config[:ssl_verify_peer]

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -687,7 +687,7 @@ module Kitchen
           subnets.first.vpc_id
         else
           # Try to check for a default VPC.
-          vpcs = ec2.client.describe_vpcs(filters: [{name: 'subnet-id', values: [config[:subnet_id]]}]).vpcs
+          vpcs = ec2.client.describe_vpcs(filters: [{name: 'isDefault', values: ['true']}]).vpcs
           if vpcs.empty?
             # No default VPC so assume EC2-Classic ¯\_(ツ)_/¯
             nil

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -85,6 +85,7 @@ module Kitchen
       default_config :tenancy,             "default"
       default_config :instance_initiated_shutdown_behavior, nil
       default_config :ssl_verify_peer, true
+      default_config :skip_cost_warning, false
 
       def initialize(*args, &block)
         super
@@ -172,7 +173,7 @@ module Kitchen
         return if state[:server_id]
         update_username(state)
 
-        info(Kitchen::Util.outdent!(<<-END))
+        info(Kitchen::Util.outdent!(<<-END)) unless config[:skip_cost_warning]
           If you are not using an account that qualifies under the AWS
           free-tier, you may be charged to run these suites. The charge
           should be minimal, but neither Test Kitchen nor its maintainers

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -33,6 +33,7 @@ require_relative "aws/standard_platform/ubuntu"
 require_relative "aws/standard_platform/windows"
 require "aws-sdk-core/waiters/errors"
 require "retryable"
+require "time"
 
 Aws.eager_autoload!
 
@@ -180,6 +181,18 @@ module Kitchen
           are responsible for your incurred costs.
         END
 
+        # If no security group IDs are specified, create one automatically.
+        unless config[:security_group_ids]
+          create_security_group(state)
+          config[:security_group_ids] = [state[:auto_security_group_id]]
+        end
+
+        # If no SSH key pair name is specified, create one automatically.
+        unless config[:aws_ssh_key_id]
+          create_key(state)
+          config[:aws_ssh_key_id] = state[:auto_key_id]
+        end
+
         if config[:spot_price]
           # Spot instance when a price is set
           server = submit_spot(state)
@@ -235,26 +248,47 @@ module Kitchen
         instance.transport.connection(state).wait_until_ready
         create_ec2_json(state)
         debug("ec2:create '#{state[:hostname]}'")
+      rescue Exception
+        # Clean up any auto-created security groups or keys on the way out.
+        delete_security_group(state)
+        delete_key(state)
+        raise
       end
 
       def destroy(state)
-        return if state[:server_id].nil?
+        if state[:server_id]
+          server = ec2.get_instance(state[:server_id])
+          unless server.nil?
+            instance.transport.connection(state).close
+            server.terminate
+          end
+          if state[:spot_request_id]
+            debug("Deleting spot request <#{state[:server_id]}>")
+            ec2.client.cancel_spot_instance_requests(
+              :spot_instance_request_ids => [state[:spot_request_id]]
+            )
+            state.delete(:spot_request_id)
+          end
+          # If we are going to clean up an automatic security group, we need
+          # to wait for the instance to shut down. This slightly breaks the
+          # subsystem encapsulation, sorry not sorry.
+          if state[:auto_security_group_id] && server
+            server.wait_until_terminated do |waiter|
+              waiter.max_attempts = config[:retryable_tries]
+              waiter.delay = config[:retryable_sleep]
+              waiter.before_attempt do |attempts|
+                info "Waited #{attempts * waiter.delay}/#{waiter.delay * waiter.max_attempts}s for instance <#{server.id}> to terminate."
+              end
+            end
+          end
+          info("EC2 instance <#{state[:server_id]}> destroyed.")
+          state.delete(:server_id)
+          state.delete(:hostname)
+        end
 
-        server = ec2.get_instance(state[:server_id])
-        unless server.nil?
-          instance.transport.connection(state).close
-          server.terminate
-        end
-        if state[:spot_request_id]
-          debug("Deleting spot request <#{state[:server_id]}>")
-          ec2.client.cancel_spot_instance_requests(
-            :spot_instance_request_ids => [state[:spot_request_id]]
-          )
-          state.delete(:spot_request_id)
-        end
-        info("EC2 instance <#{state[:server_id]}> destroyed.")
-        state.delete(:server_id)
-        state.delete(:hostname)
+        # Clean up any auto-created security groups or keys.
+        delete_security_group(state)
+        delete_key(state)
       end
 
       def image
@@ -486,7 +520,7 @@ module Kitchen
           !enc.nil? && !enc.empty?
         end
         pass = with_request_limit_backoff(state) do
-          server.decrypt_windows_password(File.expand_path(instance.transport[:ssh_key]))
+          server.decrypt_windows_password(File.expand_path(state[:ssh_key] || instance.transport[:ssh_key]))
         end
         state[:password] = pass
         info("Retrieved Windows password for instance <#{state[:server_id]}>.")
@@ -636,6 +670,110 @@ module Kitchen
         " Virtualization: #{image.virtualization_type}," \
         " Storage: #{image.root_device_type}#{volume_type}," \
         " Created: #{image.creation_date}"
+      end
+
+      # Create a temporary security group for this instance.
+      #
+      # @api private
+      # @param state [Hash] Instance state hash.
+      # @return [void]
+      def create_security_group(state)
+        return if state[:auto_security_group_id]
+        # Work out which VPC, if any, we are creating in.
+        vpc_id = if config[:subnet_id]
+          # Get the VPC ID for the subnet.
+          subnets = ec2.client.describe_subnets(filters: [{name: 'subnet-id', values: [config[:subnet_id]]}]).subnets
+          raise "Subnet #{config[:subnet_id]} not found during security group creation" if subnets.empty?
+          subnets.first.vpc_id
+        else
+          # Try to check for a default VPC.
+          vpcs = ec2.client.describe_vpcs(filters: [{name: 'subnet-id', values: [config[:subnet_id]]}]).vpcs
+          if vpcs.empty?
+            # No default VPC so assume EC2-Classic ¯\_(ツ)_/¯
+            nil
+          else
+            # I don't actually know if you can have more than one default VPC?
+            vpcs.first.vpc_id
+          end
+        end
+        # Create the SG.
+        params = {
+          group_name: "kitchen-#{Array.new(8) { rand(36).to_s(36) }.join}",
+          description: "Test Kitchen for #{instance.name} by #{Etc.getlogin || 'nologin'} on #{Socket.gethostname}",
+        }
+        params[:vpc_id] = vpc_id if vpc_id
+        resp = ec2.client.create_security_group(params)
+        state[:auto_security_group_id] = resp.group_id
+        info("Created automatic security group #{state[:auto_security_group_id]}")
+        debug("  in VPC #{vpc_id || 'none'}")
+        # Set up SG rules.
+        ec2.client.authorize_security_group_ingress(
+          group_id: state[:auto_security_group_id],
+          # Allow SSH and WinRM (both plain and TLS).
+          ip_permissions: [22, 5985, 5986].map { |port|
+            {
+              ip_protocol: 'tcp',
+              from_port: port,
+              to_port: port,
+              ip_ranges: [{cidr_ip: '0.0.0.0/0'}],
+            }
+          },
+        )
+      end
+
+      # Create a temporary SSH key pair for this instance.
+      #
+      # @api private
+      # @param state [Hash] Instance state hash.
+      # @return [void]
+      def create_key(state)
+        return if state[:auto_key_id]
+        # Encode a bunch of metadata into the name because that's all we can
+        # set for a key pair.
+        name_parts = [
+          instance.name.gsub(/\W/, ''),
+          (Etc.getlogin || 'nologin').gsub(/\W/, ''),
+          Socket.gethostname.gsub(/\W/, '')[0..20],
+          Time.now.utc.iso8601,
+          Array.new(8) { rand(36).to_s(36) }.join(''),
+        ]
+        resp = ec2.client.create_key_pair(key_name: "kitchen-#{name_parts.join('-')}")
+        state[:auto_key_id] = resp.key_name
+        info("Created automatic key pair #{state[:auto_key_id]}")
+        # Write the key out, but safely hence the weird sysopen.
+        key_path = "#{config[:kitchen_root]}/.kitchen/#{instance.name}.pem"
+        key_fd = File.sysopen(key_path, File::WRONLY|File::CREAT|File::EXCL, 00600)
+        File.open(key_fd) do |f|
+          f.write(resp.key_material)
+        end
+        # Inject the key into the state to be used by the SSH transport, or for
+        # the Windows password decrypt above in {#fetch_windows_admin_password}.
+        state[:ssh_key] = key_path
+      end
+
+      # Clean up a temporary security group for this instance.
+      #
+      # @api private
+      # @param state [Hash] Instance state hash.
+      # @return [void]
+      def delete_security_group(state)
+        return unless state[:auto_security_group_id]
+        info("Removing automatic security group #{state[:auto_security_group_id]}")
+        ec2.client.delete_security_group(group_id: state[:auto_security_group_id])
+        state.delete(:auto_security_group_id)
+      end
+
+      # Clean up a temporary SSH key pair for this instance.
+      #
+      # @api private
+      # @param state [Hash] Instance state hash.
+      # @return [void]
+      def delete_key(state)
+        return unless state[:auto_key_id]
+        info("Removing automatic key pair #{state[:auto_key_id]}")
+        ec2.client.delete_key_pair(key_name: state[:auto_key_id])
+        state.delete(:auto_key_id)
+        File.unlink("#{config[:kitchen_root]}/.kitchen/#{instance.name}.pem")
       end
 
     end

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -39,9 +39,6 @@ describe Kitchen::Driver::Aws::Client do
         Kitchen::Driver::Aws::Client.new(
           "us-west-1",
           "test-profile",
-          "access_key_id",
-          "secret_access_key",
-          "session_token",
           "http_proxy",
           999,
           false

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -30,6 +30,8 @@ describe Kitchen::Driver::Ec2 do
       :aws_ssh_key_id => "key",
       :image_id => "ami-1234567",
       :block_duration_minutes => 60,
+      :subnet_id => 'subnet-1234',
+      :security_group_ids => ['sg-56789'],
     }
   end
   let(:platform)      { Kitchen::Platform.new(:name => "fooos-99") }
@@ -520,6 +522,78 @@ describe Kitchen::Driver::Ec2 do
       end
     end
 
+    context "with no security group specified" do
+      before do
+        config.delete(:security_group_ids)
+        expect(driver).to receive(:submit_server).and_return(server)
+        allow(instance).to receive(:name).and_return("instance_name")
+      end
+
+      context "with a subnet configured" do
+        before do
+          expect(actual_client).to receive(:describe_subnets).with(filters: [{name: 'subnet-id', values: ['subnet-1234']}]).and_return(double(subnets: [double(vpc_id: 'vpc-1')]))
+          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: 'vpc-1').and_return(double(group_id: 'sg-9876'))
+          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: 'sg-9876', ip_permissions: [
+            {ip_protocol: 'tcp', from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+            {ip_protocol: 'tcp', from_port: 5985, to_port: 5985, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+            {ip_protocol: 'tcp', from_port: 5986, to_port: 5986, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+          ])
+        end
+
+        include_examples "common create"
+      end
+
+      context "with a default VPC" do
+        before do
+          config.delete(:subnet_id)
+          expect(actual_client).to receive(:describe_vpcs).with(filters: [{name: 'isDefault', values: ['true']}]).and_return(double(vpcs: [double(vpc_id: 'vpc-1')]))
+          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: 'vpc-1').and_return(double(group_id: 'sg-9876'))
+          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: 'sg-9876', ip_permissions: [
+            {ip_protocol: 'tcp', from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+            {ip_protocol: 'tcp', from_port: 5985, to_port: 5985, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+            {ip_protocol: 'tcp', from_port: 5986, to_port: 5986, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+          ])
+        end
+
+        include_examples "common create"
+      end
+
+      context "without a default VPC" do
+        before do
+          config.delete(:subnet_id)
+          expect(actual_client).to receive(:describe_vpcs).with(filters: [{name: 'isDefault', values: ['true']}]).and_return(double(vpcs: []))
+          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/).and_return(double(group_id: 'sg-9876'))
+          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: 'sg-9876', ip_permissions: [
+            {ip_protocol: 'tcp', from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+            {ip_protocol: 'tcp', from_port: 5985, to_port: 5985, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+            {ip_protocol: 'tcp', from_port: 5986, to_port: 5986, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+          ])
+        end
+
+        include_examples "common create"
+      end
+    end
+
+    context "with no key pair configured" do
+      before do
+        config[:kitchen_root] = '/kitchen'
+        config.delete(:aws_ssh_key_id)
+        expect(driver).to receive(:submit_server).and_return(server)
+        allow(instance).to receive(:name).and_return("instance_name")
+
+        expect(actual_client).to receive(:create_key_pair).with(key_name: /kitchen-/).and_return(double(key_name: 'kitchen-asdf', key_material: 'RSA PRIVATE KEY'))
+        fake_fd = double()
+        fake_file = double()
+        allow(File).to receive(:sysopen).and_call_original
+        expect(File).to receive(:sysopen).with('/kitchen/.kitchen/instance_name.pem', kind_of(Numeric), kind_of(Numeric)).and_return(fake_fd)
+        allow(File).to receive(:open).and_call_original
+        expect(File).to receive(:open).with(fake_fd).and_yield(fake_file)
+        expect(fake_file).to receive(:write).with('RSA PRIVATE KEY')
+      end
+
+      include_examples "common create"
+    end
+
   end
 
   describe "#destroy" do
@@ -559,6 +633,29 @@ describe Kitchen::Driver::Ec2 do
         expect(actual_client).to receive(:cancel_spot_instance_requests).with(
           :spot_instance_request_ids => ["spot"]
         )
+        driver.destroy(state)
+        expect(state).to eq({})
+      end
+    end
+
+    context "when the state has an automatic security group" do
+      let(:state) { { auto_security_group_id: 'sg-asdf' } }
+
+      it "destroys the security group" do
+        expect(actual_client).to receive(:delete_security_group).with(group_id: 'sg-asdf')
+        driver.destroy(state)
+        expect(state).to eq({})
+      end
+    end
+
+    context "when the state has an automatic key pair" do
+      let(:state) { { auto_key_id: 'kitchen-asdf' } }
+
+      it "destroys the key pair" do
+        config[:kitchen_root] = '/kitchen'
+        allow(instance).to receive(:name).and_return("instance_name")
+        expect(actual_client).to receive(:delete_key_pair).with(key_name: 'kitchen-asdf')
+        expect(File).to receive(:unlink).with('/kitchen/.kitchen/instance_name.pem')
         driver.destroy(state)
         expect(state).to eq({})
       end

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -30,8 +30,8 @@ describe Kitchen::Driver::Ec2 do
       :aws_ssh_key_id => "key",
       :image_id => "ami-1234567",
       :block_duration_minutes => 60,
-      :subnet_id => 'subnet-1234',
-      :security_group_ids => ['sg-56789'],
+      :subnet_id => "subnet-1234",
+      :security_group_ids => ["sg-56789"],
     }
   end
   let(:platform)      { Kitchen::Platform.new(:name => "fooos-99") }
@@ -531,12 +531,12 @@ describe Kitchen::Driver::Ec2 do
 
       context "with a subnet configured" do
         before do
-          expect(actual_client).to receive(:describe_subnets).with(filters: [{name: 'subnet-id', values: ['subnet-1234']}]).and_return(double(subnets: [double(vpc_id: 'vpc-1')]))
-          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: 'vpc-1').and_return(double(group_id: 'sg-9876'))
-          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: 'sg-9876', ip_permissions: [
-            {ip_protocol: 'tcp', from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
-            {ip_protocol: 'tcp', from_port: 5985, to_port: 5985, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
-            {ip_protocol: 'tcp', from_port: 5986, to_port: 5986, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+          expect(actual_client).to receive(:describe_subnets).with(filters: [{ name: "subnet-id", values: ["subnet-1234"] }]).and_return(double(subnets: [double(vpc_id: "vpc-1")]))
+          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: "vpc-1").and_return(double(group_id: "sg-9876"))
+          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: "sg-9876", ip_permissions: [
+            { ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }] },
+            { ip_protocol: "tcp", from_port: 5985, to_port: 5985, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }] },
+            { ip_protocol: "tcp", from_port: 5986, to_port: 5986, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }] },
           ])
         end
 
@@ -546,12 +546,12 @@ describe Kitchen::Driver::Ec2 do
       context "with a default VPC" do
         before do
           config.delete(:subnet_id)
-          expect(actual_client).to receive(:describe_vpcs).with(filters: [{name: 'isDefault', values: ['true']}]).and_return(double(vpcs: [double(vpc_id: 'vpc-1')]))
-          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: 'vpc-1').and_return(double(group_id: 'sg-9876'))
-          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: 'sg-9876', ip_permissions: [
-            {ip_protocol: 'tcp', from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
-            {ip_protocol: 'tcp', from_port: 5985, to_port: 5985, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
-            {ip_protocol: 'tcp', from_port: 5986, to_port: 5986, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+          expect(actual_client).to receive(:describe_vpcs).with(filters: [{ name: "isDefault", values: ["true"] }]).and_return(double(vpcs: [double(vpc_id: "vpc-1")]))
+          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: "vpc-1").and_return(double(group_id: "sg-9876"))
+          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: "sg-9876", ip_permissions: [
+            { ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }] },
+            { ip_protocol: "tcp", from_port: 5985, to_port: 5985, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }] },
+            { ip_protocol: "tcp", from_port: 5986, to_port: 5986, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }] },
           ])
         end
 
@@ -561,12 +561,12 @@ describe Kitchen::Driver::Ec2 do
       context "without a default VPC" do
         before do
           config.delete(:subnet_id)
-          expect(actual_client).to receive(:describe_vpcs).with(filters: [{name: 'isDefault', values: ['true']}]).and_return(double(vpcs: []))
-          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/).and_return(double(group_id: 'sg-9876'))
-          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: 'sg-9876', ip_permissions: [
-            {ip_protocol: 'tcp', from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
-            {ip_protocol: 'tcp', from_port: 5985, to_port: 5985, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
-            {ip_protocol: 'tcp', from_port: 5986, to_port: 5986, ip_ranges: [{cidr_ip: '0.0.0.0/0'}]},
+          expect(actual_client).to receive(:describe_vpcs).with(filters: [{ name: "isDefault", values: ["true"] }]).and_return(double(vpcs: []))
+          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/).and_return(double(group_id: "sg-9876"))
+          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: "sg-9876", ip_permissions: [
+            { ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }] },
+            { ip_protocol: "tcp", from_port: 5985, to_port: 5985, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }] },
+            { ip_protocol: "tcp", from_port: 5986, to_port: 5986, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }] },
           ])
         end
 
@@ -576,19 +576,19 @@ describe Kitchen::Driver::Ec2 do
 
     context "with no key pair configured" do
       before do
-        config[:kitchen_root] = '/kitchen'
+        config[:kitchen_root] = "/kitchen"
         config.delete(:aws_ssh_key_id)
         expect(driver).to receive(:submit_server).and_return(server)
         allow(instance).to receive(:name).and_return("instance_name")
 
-        expect(actual_client).to receive(:create_key_pair).with(key_name: /kitchen-/).and_return(double(key_name: 'kitchen-asdf', key_material: 'RSA PRIVATE KEY'))
+        expect(actual_client).to receive(:create_key_pair).with(key_name: /kitchen-/).and_return(double(key_name: "kitchen-asdf", key_material: "RSA PRIVATE KEY"))
         fake_fd = double()
         fake_file = double()
         allow(File).to receive(:sysopen).and_call_original
-        expect(File).to receive(:sysopen).with('/kitchen/.kitchen/instance_name.pem', kind_of(Numeric), kind_of(Numeric)).and_return(fake_fd)
+        expect(File).to receive(:sysopen).with("/kitchen/.kitchen/instance_name.pem", kind_of(Numeric), kind_of(Numeric)).and_return(fake_fd)
         allow(File).to receive(:open).and_call_original
         expect(File).to receive(:open).with(fake_fd).and_yield(fake_file)
-        expect(fake_file).to receive(:write).with('RSA PRIVATE KEY')
+        expect(fake_file).to receive(:write).with("RSA PRIVATE KEY")
       end
 
       include_examples "common create"
@@ -639,23 +639,23 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context "when the state has an automatic security group" do
-      let(:state) { { auto_security_group_id: 'sg-asdf' } }
+      let(:state) { { auto_security_group_id: "sg-asdf" } }
 
       it "destroys the security group" do
-        expect(actual_client).to receive(:delete_security_group).with(group_id: 'sg-asdf')
+        expect(actual_client).to receive(:delete_security_group).with(group_id: "sg-asdf")
         driver.destroy(state)
         expect(state).to eq({})
       end
     end
 
     context "when the state has an automatic key pair" do
-      let(:state) { { auto_key_id: 'kitchen-asdf' } }
+      let(:state) { { auto_key_id: "kitchen-asdf" } }
 
       it "destroys the key pair" do
-        config[:kitchen_root] = '/kitchen'
+        config[:kitchen_root] = "/kitchen"
         allow(instance).to receive(:name).and_return("instance_name")
-        expect(actual_client).to receive(:delete_key_pair).with(key_name: 'kitchen-asdf')
-        expect(File).to receive(:unlink).with('/kitchen/.kitchen/instance_name.pem')
+        expect(actual_client).to receive(:delete_key_pair).with(key_name: "kitchen-asdf")
+        expect(File).to receive(:unlink).with("/kitchen/.kitchen/instance_name.pem")
         driver.destroy(state)
         expect(state).to eq({})
       end


### PR DESCRIPTION
Still needs docs, but code review can start. If a security group or key pair name isn't given, it makes one for you.

Also adds an option to skip the cost warning and cleans up some defunct arguments in the Client class.