### PR TITLE
Throw a more friendly warning on bad configs

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -103,8 +103,9 @@ module Kitchen
       end
 
       def self.validation_error(driver, old_key, new_key)
-        raise "ERROR: The driver[#{driver.class.name}] config key `#{old_key}` " \
+        warn "ERROR: The driver[#{driver.class.name}] config key `#{old_key}` " \
           "has been removed, please use `#{new_key}`"
+        exit!
       end
 
       # TODO: remove these in 1.1
@@ -146,29 +147,33 @@ module Kitchen
       # Providing these inside the .kitchen.yml is no longer recommended
       validations[:aws_access_key_id] = lambda do |attr, val, _driver|
         unless val.nil?
-          raise "#{attr} is no longer valid, please use " \
-            "ENV['AWS_ACCESS_KEY_ID'] or ~/.aws/credentials.  See " \
+          warn "#{attr} is no longer a valid config option, please use " \
+            "ENV['AWS_ACCESS_KEY_ID'] or ~/.aws/credentials. See " \
             "the README for more details"
+          exit!
         end
       end
       validations[:aws_secret_access_key] = lambda do |attr, val, _driver|
         unless val.nil?
-          raise "#{attr} is no longer valid, please use " \
-            "ENV['AWS_SECRET_ACCESS_KEY'] or ~/.aws/credentials.  See " \
+          warn "#{attr} is no longer a valid config option, please use " \
+            "ENV['AWS_SECRET_ACCESS_KEY'] or ~/.aws/credentials. See " \
             "the README for more details"
+          exit!
         end
       end
       validations[:aws_session_token] = lambda do |attr, val, _driver|
         unless val.nil?
-          raise "#{attr} is no longer valid, please use " \
-            "ENV['AWS_SESSION_TOKEN'] or ~/.aws/credentials.  See " \
+          warn "#{attr} is no longer a valid config option, please use " \
+            "ENV['AWS_SESSION_TOKEN'] or ~/.aws/credentials. See " \
             "the README for more details"
+          exit!
         end
       end
       validations[:instance_initiated_shutdown_behavior] = lambda do |attr, val, _driver|
         unless [nil, "stop", "terminate"].include?(val)
-          raise "'#{val}' is an invalid value for option '#{attr}'. " \
+          warn "'#{val}' is an invalid value for option '#{attr}'. " \
             "Valid values are 'stop' or 'terminate'"
+          exit!
         end
       end
 
@@ -211,7 +216,7 @@ module Kitchen
 
         # See https://github.com/aws/aws-sdk-ruby/issues/859
         # Tagging can fail with a NotFound error even though we waited until the server exists
-        # Waiting can also fail, so we have to also retry on that.  If it means we re-tag the
+        # Waiting can also fail, so we have to also retry on that. If it means we re-tag the
         # instance, so be it.
         # Tagging an instance is possible before volumes are attached. Tagging the volumes after
         # instance creation is consistent.
@@ -350,7 +355,7 @@ module Kitchen
       def update_username(state)
         # BUG: With the following equality condition on username, if the user specifies 'root'
         # as the transport's username then we will overwrite that value with one from the standard
-        # platform definitions.  This seems difficult to handle here as the default username is
+        # platform definitions. This seems difficult to handle here as the default username is
         # provided by the underlying transport classes, and is often non-nil (eg; 'root'), leaving
         # us no way to distinguish a user-set value from the transport's default.
         # See https://github.com/test-kitchen/kitchen-ec2/pull/273
@@ -487,7 +492,7 @@ module Kitchen
         end
       end
 
-      # Poll a block, waiting for it to return true.  If it does not succeed
+      # Poll a block, waiting for it to return true. If it does not succeed
       # within the configured time we destroy the instance to save people money
       def wait_with_destroy(server, state, status_msg, &block)
         wait_log = proc do |attempts|
@@ -544,7 +549,7 @@ module Kitchen
       end
 
       #
-      # Ordered mapping from config name to Fog name.  Ordered by preference
+      # Ordered mapping from config name to Fog name. Ordered by preference
       # when looking up hostname.
       #
       INTERFACE_TYPES =
@@ -556,8 +561,8 @@ module Kitchen
         }
 
       #
-      # Lookup hostname of provided server.  If interface_type is provided use
-      # that interface to lookup hostname.  Otherwise, try ordered list of
+      # Lookup hostname of provided server. If interface_type is provided use
+      # that interface to lookup hostname. Otherwise, try ordered list of
       # options.
       #
       def hostname(server, interface_type = nil)


### PR DESCRIPTION
Raising results in a giant unfriendly stack trace we don't actually need. Just throw a warning and exit 1 so it's super clear what needs to be fixed.

This gives us this:

```
-----> Starting Kitchen (v1.20.0)
aws_access_key_id is no longer valid, please use ENV['AWS_ACCESS_KEY_ID'] or ~/.aws/credentials.  See the README for more details
```

Not this:

```
-----> Starting Kitchen (v1.20.0)
/Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/kitchen-ec2-2.1.0/lib/kitchen/driver/ec2.rb:149:in `block in <class:Ec2>': aws_access_key_id is no longer valid, please use ENV['AWS_ACCESS_KEY_ID'] or ~/.aws/credentials.  See the README for more details (RuntimeError)
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/configurable.rb:332:in `block in validate_config!'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/configurable.rb:331:in `each'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/configurable.rb:331:in `validate_config!'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/configurable.rb:52:in `finalize_config!'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/instance.rb:326:in `setup_driver'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/instance.rb:103:in `initialize'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/config.rb:246:in `new'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/config.rb:246:in `new_instance'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/config.rb:142:in `block in build_instances'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/config.rb:141:in `map'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/config.rb:141:in `with_index'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/config.rb:141:in `build_instances'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/config.rb:117:in `instances'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/command.rb:112:in `filtered_instances'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/command.rb:142:in `parse_subcommand'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/command/action.rb:35:in `block in call'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/2.4.0/benchmark.rb:293:in `measure'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/command/action.rb:34:in `call'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/cli.rb:52:in `perform'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/cli.rb:193:in `block (2 levels) in <class:CLI>'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/bin/kitchen:13:in `block in <top (required)>'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/errors.rb:171:in `with_friendly_errors'
	from /Users/tsmith/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/test-kitchen-1.20.0/bin/kitchen:13:in `<top (required)>'
	from /Users/tsmith/.rbenv/versions/2.4.3/bin/kitchen:23:in `load'
	from /Users/tsmith/.rbenv/versions/2.4.3/bin/kitchen:23:in `<main>'
```

Signed-off-by: Tim Smith <tsmith@chef.io>