### PR TITLE
Remove logic for FreeBSD < 9.1

### DIFF
--- a/lib/kitchen/driver/aws/standard_platform/freebsd.rb
+++ b/lib/kitchen/driver/aws/standard_platform/freebsd.rb
@@ -9,7 +9,7 @@ module Kitchen
           StandardPlatform.platforms["freebsd"] = self
 
           def username
-            (version && version.to_f < 9.1) ? "root" : "ec2-user"
+            "ec2-user"
           end
 
           def sudo_command


### PR DESCRIPTION
This came out in 2013 and is MANY releases EOL. FreeBSD 10 itself is just about EOL now. Let it die.

Signed-off-by: Tim Smith <tsmith@chef.io>