### PR TITLE
WIP: Break up the massive method into smaller testable methods

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --color
 --require spec_helper
---format progress
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 # Specify your gem"s dependencies in kitchen-ec2.gemspec
 gemspec
 
-gem "winrm-transport"
 gem "winrm-fs"
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "winrm-fs"
 group :test do
   gem "rake"
   gem "pry"
+  gem "test-kitchen", ">= 1.23" # defined here and in the gemspec to match sure we have lifecycle hooks for testing
 end
 
 group :changelog do

--- a/Rakefile
+++ b/Rakefile
@@ -20,13 +20,13 @@ RuboCop::RakeTask.new(:style) do |task|
 end
 
 desc "Run all quality tasks"
-task :quality => [:style, :stats]
+task quality: [:style, :stats]
 
 require "yard"
 YARD::Rake::YardocTask.new
 
 begin
-  task :default => [:test, :quality]
+  task default: [:test, :quality]
 
   require "github_changelog_generator/task"
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "test-kitchen", "~> 1.4", ">= 1.4.1"
   gem.add_dependency "excon"
   gem.add_dependency "multi_json"
-  gem.add_dependency "aws-sdk", "~> 2"
+  gem.add_dependency "aws-sdk-ec2"
   gem.add_dependency "retryable", "~> 2.0"
 
   gem.add_development_dependency "rspec",     "~> 3.2"

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |gem|
   # style and complexity libraries are tightly version pinned as newer releases
   # may introduce new and undesireable style choices which would be immediately
   # enforced in CI
-  gem.add_development_dependency "chefstyle", "= 0.6.0"
+  gem.add_development_dependency "chefstyle", "= 0.10.0"
   gem.add_development_dependency "climate_control"
 end

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -49,14 +49,24 @@ module Kitchen
           ::Aws.config.update(retry_limit: retry_limit) unless retry_limit.nil?
         end
 
+        # create a new AWS EC2 instance
+        # @param options [Hash] has of instance options
+        # @see https://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Resource.html#create_instances-instance_method
+        # @return [Aws::EC2::Instance]
         def create_instance(options)
           resource.create_instances(options)[0]
         end
 
+        # get an instance object given an id
+        # @param id [String] aws instance id
+        # @return [Aws::EC2::Instance]
         def get_instance(id)
           resource.instance(id)
         end
 
+        # get an instance object given a spot request ID
+        # @param request_id [String] aws spot instance id
+        # @return [Aws::EC2::Instance]
         def get_instance_from_spot_request(request_id)
           resource.instances(
             filters: [{

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "aws-sdk"
+require "aws-sdk-ec2"
 require "aws-sdk-core/credentials"
 require "aws-sdk-core/shared_credentials"
 require "aws-sdk-core/instance_profile_credentials"

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -41,12 +41,12 @@ module Kitchen
           ssl_verify_peer = true
         )
           ::Aws.config.update(
-            :region => region,
-            :profile => profile_name,
-            :http_proxy => http_proxy,
-            :ssl_verify_peer => ssl_verify_peer
+            region: region,
+            profile: profile_name,
+            http_proxy: http_proxy,
+            ssl_verify_peer: ssl_verify_peer
           )
-          ::Aws.config.update(:retry_limit => retry_limit) unless retry_limit.nil?
+          ::Aws.config.update(retry_limit: retry_limit) unless retry_limit.nil?
         end
 
         def create_instance(options)
@@ -59,9 +59,9 @@ module Kitchen
 
         def get_instance_from_spot_request(request_id)
           resource.instances(
-            :filters => [{
-              :name => "spot-instance-request-id",
-              :values => [request_id],
+            filters: [{
+              name: "spot-instance-request-id",
+              values: [request_id],
             }]
           ).to_a[0]
         end

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -84,12 +84,10 @@ module Kitchen
         # the matching security group IDs using that filter in the account
         # @return [Array] the security group IDs
         def security_group_ids
-          @security_ids ||= begin
-            if config[:security_group_ids]
-              Array(config[:security_group_ids])
-            elsif config[:security_group_filter]
-              security_group_ids_from_filter
-            end
+          if config[:security_group_ids]
+            Array(config[:security_group_ids])
+          elsif config[:security_group_filter]
+            security_group_ids_from_filter
           end
         end
 
@@ -97,13 +95,11 @@ module Kitchen
         # a matching subnet ID using that filter in the account
         # @return [String, nil] the subnet ID or nil
         def subnet_id
-          @subnet_ids ||= begin
           # lookup the subnet if we have a filter set and no subnet_id set
-            if config[:subnet_id]
-              config[:subnet_id]
-            elsif config[:subnet_filter]
-              subnet_id_from_filter
-            end
+          if config[:subnet_id]
+            config[:subnet_id]
+          elsif config[:subnet_filter]
+            subnet_id_from_filter
           end
         end
 
@@ -111,16 +107,14 @@ module Kitchen
         # @return [String, nil] user data or nil
         def prepared_user_data
           # If user_data is a file reference, lets read it as such
-          @user_data ||= begin
-            return nil if config[:user_data].nil?
+          return nil if config[:user_data].nil?
 
-            raw_user_data = config.fetch(:user_data)
-            if !raw_user_data.include?("\0") && ::File.file?(raw_user_data)
-              raw_user_data = ::File.read(raw_user_data)
-            end
-
-            ::Base64.encode64(raw_user_data)
+          raw_user_data = config.fetch(:user_data)
+          if !raw_user_data.include?("\0") && ::File.file?(raw_user_data)
+            raw_user_data = ::File.read(raw_user_data)
           end
+
+          ::Base64.encode64(raw_user_data)
         end
 
         # process user passed availability zone. Make sure it's

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -21,11 +21,8 @@ require "base64"
 require "aws-sdk"
 
 module Kitchen
-
   module Driver
-
     class Aws
-
       # A class for encapsulating the instance payload logic
       #
       # @author Tyler Ball <tball@chef.io>
@@ -197,11 +194,7 @@ module Kitchen
           end
           i.delete_if { |k, v| v.nil? || ( v.class == Hash && v.empty? ) }
         end
-
       end
-
     end
-
   end
-
 end

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -170,8 +170,11 @@ module Kitchen
             :key_name               => config[:aws_ssh_key_id],
             :subnet_id              => subnet_id,
             :private_ip_address     => config[:private_ip_address],
-            :placement              => placement,
           }
+
+          unless placement.empty?
+            i[:placement] = placement
+          end
 
           unless config[:block_device_mappings].nil? || config[:block_device_mappings].empty?
             i[:block_device_mappings] = config[:block_device_mappings]

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -39,132 +39,168 @@ module Kitchen
           @logger = logger
         end
 
-        # Transform the provided config into the hash to send to AWS.  Some fields
-        # can be passed in null, others need to be ommitted if they are null
-        def ec2_instance_data # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-          # Support for looking up security group id and subnet id using tags.
+        # search for the subnet_id using the provided subnet_filter
+        # @return [String] the subnet ID
+        def subnet_id_from_filter
+          subnet = ::Aws::EC2::Client.
+            new(:region => config[:region]).describe_subnets(
+              :filters => [
+                {
+                  :name   => "tag:#{config[:subnet_filter][:tag]}",
+                  :values => [config[:subnet_filter][:value]],
+                },
+              ]
+            )[0][0].subnet_id
 
-          if config[:subnet_id].nil? && config[:subnet_filter]
-            config[:subnet_id] = ::Aws::EC2::Client.
-              new(:region => config[:region]).describe_subnets(
-                :filters => [
-                  {
-                    :name   => "tag:#{config[:subnet_filter][:tag]}",
-                    :values => [config[:subnet_filter][:value]],
-                  },
-                ]
-              )[0][0].subnet_id
-
-            if config[:subnet_id].nil?
-              raise "The subnet tagged '#{config[:subnet_filter][:tag]}\
-              #{config[:subnet_filter][:value]}' does not exist!"
-            end
+          # fail if we didn't return anything
+          if subnet.nil?
+            warn "The subnet tagged '#{config[:subnet_filter][:tag]}\
+            #{config[:subnet_filter][:value]}' does not exist!"
+            exit!
           end
+          subnet
+        end
 
-          if config[:security_group_ids].nil? && config[:security_group_filter]
-            security_group = ::Aws::EC2::Client.
-                new(:region => config[:region]).describe_security_groups(
-                :filters => [
-                    {
-                        :name => "tag:#{config[:security_group_filter][:tag]}",
-                        :values => [config[:security_group_filter][:value]],
-                    },
-                ]
+        # search for the security_group_ids using the provided security_group_filter
+        # @return [Array] security group IDs
+        def security_group_ids_from_filter
+          security_group = ::Aws::EC2::Client.
+              new(:region => config[:region]).describe_security_groups(
+              :filters => [
+                  {
+                      :name => "tag:#{config[:security_group_filter][:tag]}",
+                      :values => [config[:security_group_filter][:value]],
+                  },
+              ]
             )[0][0]
 
-            if security_group
-              config[:security_group_ids] = [security_group.group_id]
-            else
-              raise "The group tagged '#{config[:security_group_filter][:tag]} " +
-                "#{config[:security_group_filter][:value]}' does not exist!"
+          # fail if we didn't return anything
+          if security_group.nil?
+            warn "The group tagged '#{config[:security_group_filter][:tag]}\
+            #{config[:security_group_filter][:value]}' does not exist!"
+            exit!
+          end
+          [security_group.group_id]
+        end
+
+        # security_group_ids if provided or if security_group_filter provided
+        # the matching security group IDs using that filter in the account
+        # @return [Array] the security group IDs
+        def security_group_ids
+          @security_ids ||= begin
+            if config[:security_group_ids]
+              Array(config[:security_group_ids])
+            elsif config[:security_group_filter]
+              security_group_ids_from_filter
             end
           end
+        end
 
+        # the provided subnet_id or if a subnet_filter is provided
+        # a matching subnet ID using that filter in the account
+        # @return [String, nil] the subnet ID or nil
+        def subnet_id
+          @subnet_ids ||= begin
+          # lookup the subnet if we have a filter set and no subnet_id set
+            if config[:subnet_id]
+              config[:subnet_id]
+            elsif config[:subnet_filter]
+              subnet_id_from_filter
+            end
+          end
+        end
+
+        # parsed user data
+        # @return [String, nil] user data or nil
+        def prepared_user_data
+          # If user_data is a file reference, lets read it as such
+          @user_data ||= begin
+            return nil if config[:user_data].nil?
+
+            raw_user_data = config.fetch(:user_data)
+            if !raw_user_data.include?("\0") && ::File.file?(raw_user_data)
+              raw_user_data = ::File.read(raw_user_data)
+            end
+
+            ::Base64.encode64(raw_user_data)
+          end
+        end
+
+        # process user passed availability zone. Make sure it's
+        # lowercase and is in region and zone format. us-east-1a
+        # @return [String, nil] the availability zone or nil
+        def availability_zone
+          return unless config[:availability_zone]
+          az = config[:availability_zone]
+          if az =~ /^[a-z]$/i
+            az = "#{config[:region]}#{availability_zone}"
+          end
+          az.downcase
+        end
+
+        # placement hash for aws connection. Adds tenancy and AZ
+        # information if provided
+        # @return [Hash] the placement hash
+        def placement
+          az_val = availability_zone
+          vals = {}
+          vals[:tenancy] = config[:tenancy] if config[:tenancy]
+          vals[:availability_zone] = az_val if az_val
+          vals
+        end
+
+        # network interface configuration information
+        def network_interfaces
+          if !config.fetch(:associate_public_ip, nil).nil?
+            [{
+              :device_index => 0,
+              :associate_public_ip_address => config[:associate_public_ip],
+              :delete_on_termination => true,
+            }]
+          end
+        end
+
+        # Transform the provided config into the hash to send to AWS.  Some fields
+        # can be passed in null, others need to be ommitted if they are null
+        def ec2_instance_data
           i = {
-            :instance_type                => config[:instance_type],
-            :ebs_optimized                => config[:ebs_optimized],
-            :image_id                     => config[:image_id],
-            :key_name                     => config[:aws_ssh_key_id],
-            :subnet_id                    => config[:subnet_id],
-            :private_ip_address           => config[:private_ip_address],
+            :instance_type          => config[:instance_type],
+            :ebs_optimized          => config[:ebs_optimized],
+            :image_id               => config[:image_id],
+            :key_name               => config[:aws_ssh_key_id],
+            :subnet_id              => subnet_id,
+            :private_ip_address     => config[:private_ip_address],
+            :placement              => placement,
           }
 
-          availability_zone = config[:availability_zone]
-          if availability_zone
-            if availability_zone =~ /^[a-z]$/i
-              availability_zone = "#{config[:region]}#{availability_zone}"
-            end
-            i[:placement] = { :availability_zone => availability_zone.downcase }
-          end
-          tenancy = config[:tenancy]
-          if tenancy
-            if i.key?(:placement)
-              i[:placement][:tenancy] = tenancy
-            else
-              i[:placement] = { :tenancy => tenancy }
-            end
-          end
           unless config[:block_device_mappings].nil? || config[:block_device_mappings].empty?
             i[:block_device_mappings] = config[:block_device_mappings]
           end
-          i[:security_group_ids] = Array(config[:security_group_ids]) if config[:security_group_ids]
+          i[:security_group_ids] = security_group_ids if security_group_ids
           i[:user_data] = prepared_user_data if prepared_user_data
           if config[:iam_profile_name]
             i[:iam_instance_profile] = { :name => config[:iam_profile_name] }
-          end
-          if !config.fetch(:associate_public_ip, nil).nil?
-            i[:network_interfaces] =
-              [{
-                :device_index => 0,
-                :associate_public_ip_address => config[:associate_public_ip],
-                :delete_on_termination => true,
-              }]
-            # If specifying `:network_interfaces` in the request, you must specify
-            # network specific configs in the network_interfaces block and not at
-            # the top level
-            if config[:subnet_id]
-              i[:network_interfaces][0][:subnet_id] = i.delete(:subnet_id)
-            end
-            if config[:private_ip_address]
-              i[:network_interfaces][0][:private_ip_address] = i.delete(:private_ip_address)
-            end
-            if config[:security_group_ids]
-              i[:network_interfaces][0][:groups] = i.delete(:security_group_ids)
-            end
-          end
-          availability_zone = config[:availability_zone]
-          if availability_zone
-            if availability_zone =~ /^[a-z]$/i
-              availability_zone = "#{config[:region]}#{availability_zone}"
-            end
-            i[:placement] = { :availability_zone => availability_zone.downcase }
-          end
-          tenancy = config[:tenancy]
-          if tenancy
-            if i.key?(:placement)
-              i[:placement][:tenancy] = tenancy
-            else
-              i[:placement] = { :tenancy => tenancy }
-            end
           end
           unless config[:instance_initiated_shutdown_behavior].nil? ||
               config[:instance_initiated_shutdown_behavior].empty?
             i[:instance_initiated_shutdown_behavior] = config[:instance_initiated_shutdown_behavior]
           end
-          i
-        end
-
-        def prepared_user_data
-          # If user_data is a file reference, lets read it as such
-          return nil if config[:user_data].nil?
-          return @user_data if @user_data
-
-          raw_user_data = config.fetch(:user_data)
-          if !raw_user_data.include?("\0") && File.file?(raw_user_data)
-            raw_user_data = File.read(raw_user_data)
+          i[:network_interfaces] = network_interfaces
+          # If specifying `:network_interfaces` in the request, you must specify
+          # network specific configs in the network_interfaces block and not at
+          # the top level
+          if i[:network_interfaces]
+            if config[:subnet_id]
+              interfaces[0][:subnet_id] = i.delete(:subnet_id)
+            end
+            if config[:private_ip_address]
+              interfaces[0][:private_ip_address] = i.delete(:private_ip_address)
+            end
+            if config[:security_group_ids]
+              interfaces[0][:groups] = i.delete(:security_group_ids)
+            end
           end
-
-          @user_data = Base64.encode64(raw_user_data)
+          i
         end
 
       end

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -170,25 +170,17 @@ module Kitchen
             :key_name               => config[:aws_ssh_key_id],
             :subnet_id              => subnet_id,
             :private_ip_address     => config[:private_ip_address],
+            :placement              => placement,
+            :block_device_mappings  => config[:block_device_mappings],
+            :user_data              => prepared_user_data,
+            :security_group_ids     => security_group_ids,
+            :network_interfaces     => network_interfaces,
+            :instance_initiated_shutdown_behavior => config[:instance_initiated_shutdown_behavior],
           }
 
-          unless placement.empty?
-            i[:placement] = placement
-          end
-
-          unless config[:block_device_mappings].nil? || config[:block_device_mappings].empty?
-            i[:block_device_mappings] = config[:block_device_mappings]
-          end
-          i[:security_group_ids] = security_group_ids if security_group_ids
-          i[:user_data] = prepared_user_data if prepared_user_data
           if config[:iam_profile_name]
             i[:iam_instance_profile] = { :name => config[:iam_profile_name] }
           end
-          unless config[:instance_initiated_shutdown_behavior].nil? ||
-              config[:instance_initiated_shutdown_behavior].empty?
-            i[:instance_initiated_shutdown_behavior] = config[:instance_initiated_shutdown_behavior]
-          end
-          i[:network_interfaces] = network_interfaces
           # If specifying `:network_interfaces` in the request, you must specify
           # network specific configs in the network_interfaces block and not at
           # the top level
@@ -203,7 +195,7 @@ module Kitchen
               i[:network_interfaces][0][:groups] = i.delete(:security_group_ids)
             end
           end
-          i
+          i.delete_if { |k, v| v.nil? || ( v.class == Hash && v.empty? ) }
         end
 
       end

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -73,9 +73,10 @@ module Kitchen
 
           # fail if we didn't return anything
           if security_group.nil?
-            warn "The group tagged '#{config[:security_group_filter][:tag]}\
+            error_message = "The group tagged '#{config[:security_group_filter][:tag]}\
             #{config[:security_group_filter][:value]}' does not exist!"
-            exit!
+            warn error_message
+            raise error_message
           end
           [security_group.group_id]
         end

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -194,13 +194,13 @@ module Kitchen
           # the top level
           if i[:network_interfaces]
             if config[:subnet_id]
-              interfaces[0][:subnet_id] = i.delete(:subnet_id)
+              i[:network_interfaces][0][:subnet_id] = i.delete(:subnet_id)
             end
             if config[:private_ip_address]
-              interfaces[0][:private_ip_address] = i.delete(:private_ip_address)
+              i[:network_interfaces][0][:private_ip_address] = i.delete(:private_ip_address)
             end
             if config[:security_group_ids]
-              interfaces[0][:groups] = i.delete(:security_group_ids)
+              i[:network_interfaces][0][:groups] = i.delete(:security_group_ids)
             end
           end
           i

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -133,7 +133,7 @@ module Kitchen
           return unless config[:availability_zone]
           az = config[:availability_zone]
           if az =~ /^[a-z]$/i
-            az = "#{config[:region]}#{availability_zone}"
+            az = "#{config[:region]}#{az}"
           end
           az.downcase
         end

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -36,30 +36,29 @@ module Kitchen
           @logger = logger
         end
 
-
         # Transform the provided config into the hash to send to AWS.  Some fields
         # can be passed in null, others need to be ommitted if they are null
         def ec2_instance_data
           i = {
-            :instance_type          => config[:instance_type],
-            :ebs_optimized          => config[:ebs_optimized],
-            :image_id               => config[:image_id],
-            :key_name               => config[:aws_ssh_key_id],
-            :subnet_id              => subnet_id,
-            :private_ip_address     => config[:private_ip_address],
-            :placement              => placement,
-            :block_device_mappings  => config[:block_device_mappings],
-            :user_data              => prepared_user_data,
-            :security_group_ids     => security_group_ids,
-            :network_interfaces     => network_interfaces,
-            :instance_initiated_shutdown_behavior => config[:instance_initiated_shutdown_behavior],
+            instance_type:                        config[:instance_type],
+            ebs_optimized:                        config[:ebs_optimized],
+            image_id:                             config[:image_id],
+            key_name:                             config[:aws_ssh_key_id],
+            subnet_id:                            subnet_id,
+            private_ip_address:                   config[:private_ip_address],
+            placement:                            placement,
+            block_device_mappings:                config[:block_device_mappings],
+            user_data:                            prepared_user_data,
+            security_group_ids:                   security_group_ids,
+            network_interfaces:                   network_interfaces,
+            instance_initiated_shutdown_behavior: config[:instance_initiated_shutdown_behavior],
           }
 
           if config[:iam_profile_name]
-            i[:iam_instance_profile] = { :name => config[:iam_profile_name] }
+            i[:iam_instance_profile] = { name: config[:iam_profile_name] }
           end
 
-         remove_empty_fields i
+          remove_empty_fields i
         end
 
         private
@@ -67,12 +66,12 @@ module Kitchen
                 # search for the subnet_id using the provided subnet_filter
         # @return [String] the subnet ID
         def subnet_id_from_filter
-          subnet = ::Aws::EC2::Client.
-            new(:region => config[:region]).describe_subnets(
-              :filters => [
+          subnet = ::Aws::EC2::Client
+            .new(region: config[:region]).describe_subnets(
+              filters: [
                 {
-                  :name   => "tag:#{config[:subnet_filter][:tag]}",
-                  :values => [config[:subnet_filter][:value]],
+                  name: "tag:#{config[:subnet_filter][:tag]}",
+                  values: [config[:subnet_filter][:value]],
                 },
               ]
             )[0][0].subnet_id
@@ -89,12 +88,12 @@ module Kitchen
         # search for the security_group_ids using the provided security_group_filter
         # @return [Array] security group IDs
         def security_group_ids_from_filter
-          security_group = ::Aws::EC2::Client.
-              new(:region => config[:region]).describe_security_groups(
-              :filters => [
+          security_group = ::Aws::EC2::Client
+              .new(region: config[:region]).describe_security_groups(
+              filters: [
                   {
-                      :name => "tag:#{config[:security_group_filter][:tag]}",
-                      :values => [config[:security_group_filter][:value]],
+                      name: "tag:#{config[:security_group_filter][:tag]}",
+                      values: [config[:security_group_filter][:value]],
                   },
               ]
             )[0][0]
@@ -193,9 +192,9 @@ module Kitchen
         end
 
         def remove_empty_fields(settings)
-          fields_that_should_not_be_present_if_nil_or_empty = %i[
+          fields_that_should_not_be_present_if_nil_or_empty = %i{
             block_device_mappings instance_initiated_shutdown_behavior network_interfaces placement security_group_ids user_data
-          ]
+          }
 
           fields_that_should_not_be_present_if_nil_or_empty.each do |field|
             settings.delete(field) if settings[field].nil? || settings[field].empty?

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 require "base64"
-require "aws-sdk"
+require "aws-sdk-ec2"
 
 module Kitchen
   module Driver
@@ -36,8 +36,8 @@ module Kitchen
           @logger = logger
         end
 
-        # Transform the provided config into the hash to send to AWS.  Some fields
-        # can be passed in null, others need to be ommitted if they are null
+        # Transform the provided kitchen config into the hash we'll use to create the aws instance
+        # Some fields can be passed in null, others need to be ommitted if they are null
         # @return [Hash]
         def ec2_instance_data
           i = {

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -38,6 +38,7 @@ module Kitchen
 
         # Transform the provided config into the hash to send to AWS.  Some fields
         # can be passed in null, others need to be ommitted if they are null
+        # @return [Hash]
         def ec2_instance_data
           i = {
             instance_type:                        config[:instance_type],
@@ -63,7 +64,7 @@ module Kitchen
 
         private
 
-                # search for the subnet_id using the provided subnet_filter
+        # search for the subnet_id using the provided subnet_filter
         # @return [String] the subnet ID
         def subnet_id_from_filter
           subnet = ::Aws::EC2::Client

--- a/lib/kitchen/driver/aws/standard_platform.rb
+++ b/lib/kitchen/driver/aws/standard_platform.rb
@@ -93,11 +93,11 @@ module Kitchen
           driver.debug("Searching for images matching #{image_search} ...")
           # Convert to ec2 search format (pairs of name+values)
           filters = image_search.map do |key, value|
-            { :name => key.to_s, :values => Array(value).map(&:to_s) }
+            { name: key.to_s, values: Array(value).map(&:to_s) }
           end
 
           # We prefer most recent first
-          images = driver.ec2.resource.images(:filters => filters)
+          images = driver.ec2.resource.images(filters: filters)
           images = sort_images(images)
           show_returned_images(images)
 
@@ -154,7 +154,7 @@ module Kitchen
         #
         # The list of supported architectures
         #
-        ARCHITECTURE = %w{x86_64 i386 i86pc sun4v powerpc}
+        ARCHITECTURE = %w{x86_64 i386 i86pc sun4v powerpc}.freeze
 
         protected
 
@@ -189,8 +189,6 @@ module Kitchen
           matching + non_matching
         end
 
-        private
-
         def self.parse_platform_string(platform_string)
           platform, version = platform_string.split("-", 2)
 
@@ -204,6 +202,10 @@ module Kitchen
 
           [platform, version, architecture]
         end
+
+        private_class_method :parse_platform_string
+
+        private
 
         def sort_images(images)
           # P6: We prefer more recent images over older ones

--- a/lib/kitchen/driver/aws/standard_platform/amazon.rb
+++ b/lib/kitchen/driver/aws/standard_platform/amazon.rb
@@ -23,6 +23,8 @@ module Kitchen
         class Amazon < StandardPlatform
           StandardPlatform.platforms["amazon"] = self
 
+          # default username for this platform's ami
+          # @return [String]
           def username
             "ec2-user"
           end

--- a/lib/kitchen/driver/aws/standard_platform/centos.rb
+++ b/lib/kitchen/driver/aws/standard_platform/centos.rb
@@ -23,6 +23,8 @@ module Kitchen
         class Centos < StandardPlatform
           StandardPlatform.platforms["centos"] = self
 
+          # default username for this platform's ami
+          # @return [String]
           def username
             # Centos 6.x images use root as the username (but the "centos 6"
             # updateable image uses "centos")

--- a/lib/kitchen/driver/aws/standard_platform/centos.rb
+++ b/lib/kitchen/driver/aws/standard_platform/centos.rb
@@ -43,9 +43,9 @@ module Kitchen
             # 7.1 -> [ img1, img2, img3 ]
             # 6 -> [ img4, img5 ]
             # ...
-            images.group_by { |image| self.class.from_image(driver, image).version }.
-              sort_by { |k, _v| (k && k.include?(".") ? k.to_f : "#{k}.999".to_f) }.
-              reverse.flat_map { |_k, v| v }
+            images.group_by { |image| self.class.from_image(driver, image).version }
+              .sort_by { |k, _v| (k && k.include?(".") ? k.to_f : "#{k}.999".to_f) }
+              .reverse.flat_map { |_k, v| v }
           end
 
           def self.from_image(driver, image)

--- a/lib/kitchen/driver/aws/standard_platform/debian.rb
+++ b/lib/kitchen/driver/aws/standard_platform/debian.rb
@@ -34,6 +34,8 @@ module Kitchen
             "10" => "buster",
           }.freeze
 
+          # default username for this platform's ami
+          # @return [String]
           def username
             "admin"
           end

--- a/lib/kitchen/driver/aws/standard_platform/debian.rb
+++ b/lib/kitchen/driver/aws/standard_platform/debian.rb
@@ -32,7 +32,7 @@ module Kitchen
             "6" => "squeeze",
             "11" => "bullseye",
             "10" => "buster",
-          }
+          }.freeze
 
           def username
             "admin"

--- a/lib/kitchen/driver/aws/standard_platform/fedora.rb
+++ b/lib/kitchen/driver/aws/standard_platform/fedora.rb
@@ -23,6 +23,8 @@ module Kitchen
         class Fedora < StandardPlatform
           StandardPlatform.platforms["fedora"] = self
 
+          # default username for this platform's ami
+          # @return [String]
           def username
             "fedora"
           end

--- a/lib/kitchen/driver/aws/standard_platform/freebsd.rb
+++ b/lib/kitchen/driver/aws/standard_platform/freebsd.rb
@@ -23,6 +23,8 @@ module Kitchen
         class Freebsd < StandardPlatform
           StandardPlatform.platforms["freebsd"] = self
 
+          # default username for this platform's ami
+          # @return [String]
           def username
             "ec2-user"
           end

--- a/lib/kitchen/driver/aws/standard_platform/rhel.rb
+++ b/lib/kitchen/driver/aws/standard_platform/rhel.rb
@@ -29,6 +29,8 @@ module Kitchen
             super(driver, "rhel", version, architecture)
           end
 
+          # default username for this platform's ami
+          # @return [String]
           def username
             (version && version.to_f < 6.4) ? "root" : "ec2-user"
           end

--- a/lib/kitchen/driver/aws/standard_platform/ubuntu.rb
+++ b/lib/kitchen/driver/aws/standard_platform/ubuntu.rb
@@ -23,6 +23,8 @@ module Kitchen
         class Ubuntu < StandardPlatform
           StandardPlatform.platforms["ubuntu"] = self
 
+          # default username for this platform's ami
+          # @return [String]
           def username
             "ubuntu"
           end

--- a/lib/kitchen/driver/aws/standard_platform/windows.rb
+++ b/lib/kitchen/driver/aws/standard_platform/windows.rb
@@ -23,11 +23,13 @@ module Kitchen
         class Windows < StandardPlatform
           StandardPlatform.platforms["windows"] = self
 
+          # default username for this platform's ami
+          # @return [String]
           def username
             "administrator"
           end
 
-          # Figure out the right set of names to search for:
+          # Determine the correct set of names to search for:
           #
           # "windows" -> [nil, nil, nil]
           #   Windows_Server-*-R*_RTM-, Windows_Server-*-R*_SP*-,

--- a/lib/kitchen/driver/aws/standard_platform/windows.rb
+++ b/lib/kitchen/driver/aws/standard_platform/windows.rb
@@ -60,9 +60,9 @@ module Kitchen
             # 2008r2rtm -> [ img1, img2, img3 ]
             # 2012r2sp1 -> [ img4, img5 ]
             # ...
-            images.group_by { |image| self.class.from_image(driver, image).windows_version_parts }.
-              sort_by { |version, _platform_images| version }.
-              reverse.flat_map { |_version, platform_images| platform_images }
+            images.group_by { |image| self.class.from_image(driver, image).windows_version_parts }
+              .sort_by { |version, _platform_images| version }
+              .reverse.flat_map { |_version, platform_images| platform_images }
           end
 
           def self.from_image(driver, image)

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -250,15 +250,15 @@ module Kitchen
         # Tagging an instance is possible before volumes are attached. Tagging the volumes after
         # instance creation is consistent.
         Retryable.retryable(
-          :tries => 10,
-          :sleep => lambda { |n| [2**n, 30].min },
-          :on => ::Aws::EC2::Errors::InvalidInstanceIDNotFound
+          tries: 10,
+          sleep: lambda { |n| [2**n, 30].min },
+          on: ::Aws::EC2::Errors::InvalidInstanceIDNotFound
         ) do |r, _|
           info("Attempting to tag the instance, #{r} retries")
           tag_server(server)
 
           # Get information about the AMI (image) used to create the image.
-          image_data = ec2.client.describe_images({ :image_ids => [server.image_id] })[0][0]
+          image_data = ec2.client.describe_images({ image_ids: [server.image_id] })[0][0]
 
           state[:server_id] = server.id
           info("EC2 instance <#{state[:server_id]}> created.")
@@ -301,7 +301,7 @@ module Kitchen
           if state[:spot_request_id]
             debug("Deleting spot request <#{state[:server_id]}>")
             ec2.client.cancel_spot_instance_requests(
-              :spot_instance_request_ids => [state[:spot_request_id]]
+              spot_instance_request_ids: [state[:spot_request_id]]
             )
             state.delete(:spot_request_id)
           end
@@ -431,7 +431,7 @@ module Kitchen
         state[:spot_request_id] = spot_request_id
         ec2.client.wait_until(
           :spot_instance_request_fulfilled,
-          :spot_instance_request_ids => [spot_request_id]
+          spot_instance_request_ids: [spot_request_id]
         ) do |w|
           w.max_attempts = config[:retryable_tries]
           w.delay = config[:retryable_sleep]
@@ -447,9 +447,9 @@ module Kitchen
       def create_spot_request
         request_duration = config[:retryable_tries] * config[:retryable_sleep]
         request_data = {
-          :spot_price => config[:spot_price].to_s,
-          :launch_specification => instance_generator.ec2_instance_data,
-          :valid_until => Time.now + request_duration,
+          spot_price: config[:spot_price].to_s,
+          launch_specification: instance_generator.ec2_instance_data,
+          valid_until: Time.now + request_duration,
         }
         if config[:block_duration_minutes]
           request_data[:block_duration_minutes] = config[:block_duration_minutes]
@@ -465,19 +465,19 @@ module Kitchen
             # we convert the value to a string because
             # nils should be passed as an empty String
             # and Integers need to be represented as Strings
-            { :key => k, :value => v.to_s }
+            { key: k, value: v.to_s }
           end
-          server.create_tags(:tags => tags)
+          server.create_tags(tags: tags)
         end
       end
 
       def tag_volumes(server)
         if config[:tags] && !config[:tags].empty?
           tags = config[:tags].map do |k, v|
-            { :key => k, :value => v.to_s }
+            { key: k, value: v.to_s }
           end
           server.volumes.each do |volume|
-            volume.create_tags(:tags => tags)
+            volume.create_tags(tags: tags)
           end
         end
       end
@@ -491,8 +491,8 @@ module Kitchen
           described_volume_count = 0
           ready_volume_count = 0
           if aws_instance.exists?
-            described_volume_count = ec2.client.describe_volumes(:filters => [
-              { :name => "attachment.instance-id", :values => ["#{state[:server_id]}"] }]
+            described_volume_count = ec2.client.describe_volumes(filters: [
+              { name: "attachment.instance-id", values: ["#{state[:server_id]}"] }]
               ).volumes.length
             aws_instance.volumes.each { ready_volume_count += 1 }
           end
@@ -535,9 +535,9 @@ module Kitchen
         begin
           with_request_limit_backoff(state) do
             server.wait_until(
-              :max_attempts => config[:retryable_tries],
-              :delay => config[:retryable_sleep],
-              :before_attempt => wait_log,
+              max_attempts: config[:retryable_tries],
+              delay: config[:retryable_sleep],
+              before_attempt: wait_log,
               &block
             )
           end
@@ -552,7 +552,7 @@ module Kitchen
       def fetch_windows_admin_password(server, state)
         wait_with_destroy(server, state, "to fetch windows admin password") do |aws_instance|
           enc = server.client.get_password_data(
-            :instance_id => state[:server_id]
+            instance_id: state[:server_id]
           ).password_data
           # Password data is blank until password is available
           !enc.nil? && !enc.empty?
@@ -588,7 +588,7 @@ module Kitchen
           "public" => "public_ip_address",
           "private" => "private_ip_address",
           "private_dns" => "private_dns_name",
-        }
+        }.freeze
 
       #
       # Lookup hostname of provided server. If interface_type is provided use
@@ -706,8 +706,8 @@ module Kitchen
       end
 
       def image_info(image)
-        root_device = image.block_device_mappings.
-          find { |b| b.device_name == image.root_device_name }
+        root_device = image.block_device_mappings
+          .find { |b| b.device_name == image.root_device_name }
         volume_type = " #{root_device.ebs.volume_type}" if root_device && root_device.ebs
 
         " Architecture: #{image.architecture}," \

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -22,6 +22,6 @@ module Kitchen
   module Driver
 
     # Version string for EC2 Test Kitchen driver
-    EC2_VERSION = "2.2.2"
+    EC2_VERSION = "2.2.2".freeze
   end
 end

--- a/spec/kitchen/driver/ec2/image_selection_spec.rb
+++ b/spec/kitchen/driver/ec2/image_selection_spec.rb
@@ -23,9 +23,12 @@ describe "Default images for various platforms" do
   let(:driver) do
     Kitchen::Driver::Ec2.new(:region => "us-west-2", :aws_ssh_key_id => "foo", **config)
   end
+  let(:logged_output) { StringIO.new }
+  let(:logger)        { Logger.new(logged_output) }
   let(:config) { {} }
   def new_instance(platform_name: "blarghle")
     Kitchen::Instance.new(
+      :logger => logger,
       :driver => driver,
       :suite => Kitchen::Suite.new(:name => "suite-name"),
       :platform => Kitchen::Platform.new(:name => platform_name),

--- a/spec/kitchen/driver/ec2/image_selection_spec.rb
+++ b/spec/kitchen/driver/ec2/image_selection_spec.rb
@@ -30,6 +30,7 @@ describe "Default images for various platforms" do
     Kitchen::Instance.new(
       logger: logger,
       driver: driver,
+      lifecycle_hooks: Kitchen::LifecycleHooks.new({}),
       suite: Kitchen::Suite.new(name: "suite-name"),
       platform: Kitchen::Platform.new(name: platform_name),
       provisioner: Kitchen::Provisioner::Dummy.new,

--- a/spec/kitchen/driver/ec2/image_selection_spec.rb
+++ b/spec/kitchen/driver/ec2/image_selection_spec.rb
@@ -21,219 +21,219 @@ require "kitchen/verifier/dummy"
 
 describe "Default images for various platforms" do
   let(:driver) do
-    Kitchen::Driver::Ec2.new(:region => "us-west-2", :aws_ssh_key_id => "foo", **config)
+    Kitchen::Driver::Ec2.new(region: "us-west-2", aws_ssh_key_id: "foo", **config)
   end
   let(:logged_output) { StringIO.new }
   let(:logger)        { Logger.new(logged_output) }
   let(:config) { {} }
   def new_instance(platform_name: "blarghle")
     Kitchen::Instance.new(
-      :logger => logger,
-      :driver => driver,
-      :suite => Kitchen::Suite.new(:name => "suite-name"),
-      :platform => Kitchen::Platform.new(:name => platform_name),
-      :provisioner => Kitchen::Provisioner::Dummy.new,
-      :transport => Kitchen::Transport::Dummy.new,
-      :verifier => Kitchen::Verifier::Dummy.new,
-      :state_file => Kitchen::StateFile.new("/nonexistent", "suite-name-#{platform_name}")
+      logger: logger,
+      driver: driver,
+      suite: Kitchen::Suite.new(name: "suite-name"),
+      platform: Kitchen::Platform.new(name: platform_name),
+      provisioner: Kitchen::Provisioner::Dummy.new,
+      transport: Kitchen::Transport::Dummy.new,
+      verifier: Kitchen::Verifier::Dummy.new,
+      state_file: Kitchen::StateFile.new("/nonexistent", "suite-name-#{platform_name}")
     )
   end
 
   PLATFORM_SEARCHES = {
     "amazon" => [
-      { :name => "owner-id", :values => %w{137112412989} },
-      { :name => "name", :values => %w{amzn-ami-*} },
+      { name: "owner-id", values: %w{137112412989} },
+      { name: "name", values: %w{amzn-ami-*} },
     ],
     "amazon-x86_64" => [
-      { :name => "owner-id", :values => %w{137112412989} },
-      { :name => "name", :values => %w{amzn-ami-*} },
-      { :name => "architecture", :values => ["x86_64"] },
+      { name: "owner-id", values: %w{137112412989} },
+      { name: "name", values: %w{amzn-ami-*} },
+      { name: "architecture", values: ["x86_64"] },
     ],
     "amazon-2016" => [
-      { :name => "owner-id", :values => %w{137112412989} },
-      { :name => "name", :values => %w{amzn-ami-*-2016*} },
+      { name: "owner-id", values: %w{137112412989} },
+      { name: "name", values: %w{amzn-ami-*-2016*} },
     ],
     "amazon-2017" => [
-      { :name => "owner-id", :values => %w{137112412989} },
-      { :name => "name", :values => %w{amzn-ami-*-2017*} },
+      { name: "owner-id", values: %w{137112412989} },
+      { name: "name", values: %w{amzn-ami-*-2017*} },
     ],
     "amazon-2016.09" => [
-      { :name => "owner-id", :values => %w{137112412989} },
-      { :name => "name", :values => %w{amzn-ami-*-2016.09*} },
+      { name: "owner-id", values: %w{137112412989} },
+      { name: "name", values: %w{amzn-ami-*-2016.09*} },
     ],
     "amazon-2017.03" => [
-      { :name => "owner-id", :values => %w{137112412989} },
-      { :name => "name", :values => %w{amzn-ami-*-2017.03*} },
+      { name: "owner-id", values: %w{137112412989} },
+      { name: "name", values: %w{amzn-ami-*-2017.03*} },
     ],
     "amazon-2017.03-x86_64" => [
-      { :name => "owner-id", :values => %w{137112412989} },
-      { :name => "name", :values => %w{amzn-ami-*-2017.03*} },
-      { :name => "architecture", :values => ["x86_64"] },
+      { name: "owner-id", values: %w{137112412989} },
+      { name: "name", values: %w{amzn-ami-*-2017.03*} },
+      { name: "architecture", values: ["x86_64"] },
     ],
 
     "centos" => [
-      { :name => "owner-alias", :values => %w{aws-marketplace} },
-      { :name => "name", :values => ["CentOS Linux *", "CentOS-*-GA-*"] },
+      { name: "owner-alias", values: %w{aws-marketplace} },
+      { name: "name", values: ["CentOS Linux *", "CentOS-*-GA-*"] },
     ],
     "centos-7" => [
-      { :name => "owner-alias", :values => %w{aws-marketplace} },
-      { :name => "name", :values => ["CentOS Linux 7*", "CentOS-7*-GA-*"] },
+      { name: "owner-alias", values: %w{aws-marketplace} },
+      { name: "name", values: ["CentOS Linux 7*", "CentOS-7*-GA-*"] },
     ],
     "centos-6" => [
-      { :name => "owner-alias", :values => %w{aws-marketplace} },
-      { :name => "name", :values => ["CentOS Linux 6*", "CentOS-6*-GA-*"] },
+      { name: "owner-alias", values: %w{aws-marketplace} },
+      { name: "name", values: ["CentOS Linux 6*", "CentOS-6*-GA-*"] },
     ],
     "centos-6.3" => [
-      { :name => "owner-alias", :values => %w{aws-marketplace} },
-      { :name => "name", :values => ["CentOS Linux 6.3*", "CentOS-6.3*-GA-*"] },
+      { name: "owner-alias", values: %w{aws-marketplace} },
+      { name: "name", values: ["CentOS Linux 6.3*", "CentOS-6.3*-GA-*"] },
     ],
     "centos-x86_64" => [
-      { :name => "owner-alias", :values => %w{aws-marketplace} },
-      { :name => "name", :values => ["CentOS Linux *", "CentOS-*-GA-*"] },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-alias", values: %w{aws-marketplace} },
+      { name: "name", values: ["CentOS Linux *", "CentOS-*-GA-*"] },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "centos-6.3-x86_64" => [
-      { :name => "owner-alias", :values => %w{aws-marketplace} },
-      { :name => "name", :values => ["CentOS Linux 6.3*", "CentOS-6.3*-GA-*"] },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-alias", values: %w{aws-marketplace} },
+      { name: "name", values: ["CentOS Linux 6.3*", "CentOS-6.3*-GA-*"] },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "centos-7-x86_64" => [
-      { :name => "owner-alias", :values => %w{aws-marketplace} },
-      { :name => "name", :values => ["CentOS Linux 7*", "CentOS-7*-GA-*"] },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-alias", values: %w{aws-marketplace} },
+      { name: "name", values: ["CentOS Linux 7*", "CentOS-7*-GA-*"] },
+      { name: "architecture", values: %w{x86_64} },
     ],
 
     "debian" => [
-      { :name => "owner-id", :values => %w{379101102735} },
-      { :name => "name", :values => %w{debian-stretch-*} },
+      { name: "owner-id", values: %w{379101102735} },
+      { name: "name", values: %w{debian-stretch-*} },
     ],
     "debian-9" => [
-      { :name => "owner-id", :values => %w{379101102735} },
-      { :name => "name", :values => %w{debian-stretch-*} },
+      { name: "owner-id", values: %w{379101102735} },
+      { name: "name", values: %w{debian-stretch-*} },
     ],
     "debian-8" => [
-      { :name => "owner-id", :values => %w{379101102735} },
-      { :name => "name", :values => %w{debian-jessie-*} },
+      { name: "owner-id", values: %w{379101102735} },
+      { name: "name", values: %w{debian-jessie-*} },
     ],
     "debian-7" => [
-      { :name => "owner-id", :values => %w{379101102735} },
-      { :name => "name", :values => %w{debian-wheezy-*} },
+      { name: "owner-id", values: %w{379101102735} },
+      { name: "name", values: %w{debian-wheezy-*} },
     ],
     "debian-6" => [
-      { :name => "owner-id", :values => %w{379101102735} },
-      { :name => "name", :values => %w{debian-squeeze-*} },
+      { name: "owner-id", values: %w{379101102735} },
+      { name: "name", values: %w{debian-squeeze-*} },
     ],
     "debian-x86_64" => [
-      { :name => "owner-id", :values => %w{379101102735} },
-      { :name => "name", :values => %w{debian-stretch-*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{379101102735} },
+      { name: "name", values: %w{debian-stretch-*} },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "debian-6-x86_64" => [
-      { :name => "owner-id", :values => %w{379101102735} },
-      { :name => "name", :values => %w{debian-squeeze-*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{379101102735} },
+      { name: "name", values: %w{debian-squeeze-*} },
+      { name: "architecture", values: %w{x86_64} },
     ],
 
     "rhel" => [
-      { :name => "owner-id", :values => %w{309956199498} },
-      { :name => "name", :values => %w{RHEL-*} },
+      { name: "owner-id", values: %w{309956199498} },
+      { name: "name", values: %w{RHEL-*} },
     ],
     "rhel-6" => [
-      { :name => "owner-id", :values => %w{309956199498} },
-      { :name => "name", :values => %w{RHEL-6*} },
+      { name: "owner-id", values: %w{309956199498} },
+      { name: "name", values: %w{RHEL-6*} },
     ],
     "rhel-7.1" => [
-      { :name => "owner-id", :values => %w{309956199498} },
-      { :name => "name", :values => %w{RHEL-7.1*} },
+      { name: "owner-id", values: %w{309956199498} },
+      { name: "name", values: %w{RHEL-7.1*} },
     ],
     "rhel-x86_64" => [
-      { :name => "owner-id", :values => %w{309956199498} },
-      { :name => "name", :values => %w{RHEL-*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{309956199498} },
+      { name: "name", values: %w{RHEL-*} },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "rhel-6-x86_64" => [
-      { :name => "owner-id", :values => %w{309956199498} },
-      { :name => "name", :values => %w{RHEL-6*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{309956199498} },
+      { name: "name", values: %w{RHEL-6*} },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "el" => [
-      { :name => "owner-id", :values => %w{309956199498} },
-      { :name => "name", :values => %w{RHEL-*} },
+      { name: "owner-id", values: %w{309956199498} },
+      { name: "name", values: %w{RHEL-*} },
     ],
     "el-6-x86_64" => [
-      { :name => "owner-id", :values => %w{309956199498} },
-      { :name => "name", :values => %w{RHEL-6*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{309956199498} },
+      { name: "name", values: %w{RHEL-6*} },
+      { name: "architecture", values: %w{x86_64} },
     ],
 
     "fedora" => [
-      { :name => "owner-id", :values => %w{125523088429} },
-      { :name => "name", :values => %w{Fedora-Cloud-Base-*} },
+      { name: "owner-id", values: %w{125523088429} },
+      { name: "name", values: %w{Fedora-Cloud-Base-*} },
     ],
     "fedora-22" => [
-      { :name => "owner-id", :values => %w{125523088429} },
-      { :name => "name", :values => %w{Fedora-Cloud-Base-22-*} },
+      { name: "owner-id", values: %w{125523088429} },
+      { name: "name", values: %w{Fedora-Cloud-Base-22-*} },
     ],
     "fedora-x86_64" => [
-      { :name => "owner-id", :values => %w{125523088429} },
-      { :name => "name", :values => %w{Fedora-Cloud-Base-*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{125523088429} },
+      { name: "name", values: %w{Fedora-Cloud-Base-*} },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "fedora-22-x86_64" => [
-      { :name => "owner-id", :values => %w{125523088429} },
-      { :name => "name", :values => %w{Fedora-Cloud-Base-22-*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{125523088429} },
+      { name: "name", values: %w{Fedora-Cloud-Base-22-*} },
+      { name: "architecture", values: %w{x86_64} },
     ],
 
     "freebsd" => [
-      { :name => "owner-id", :values => %w{118940168514} },
-      { :name => "name", :values => ["FreeBSD *-RELEASE*", "FreeBSD/EC2 *-RELEASE*"] },
+      { name: "owner-id", values: %w{118940168514} },
+      { name: "name", values: ["FreeBSD *-RELEASE*", "FreeBSD/EC2 *-RELEASE*"] },
     ],
     "freebsd-10" => [
-      { :name => "owner-id", :values => %w{118940168514} },
-      { :name => "name", :values => ["FreeBSD 10*-RELEASE*", "FreeBSD/EC2 10*-RELEASE*"] },
+      { name: "owner-id", values: %w{118940168514} },
+      { name: "name", values: ["FreeBSD 10*-RELEASE*", "FreeBSD/EC2 10*-RELEASE*"] },
     ],
     "freebsd-10.1" => [
-      { :name => "owner-id", :values => %w{118940168514} },
-      { :name => "name", :values => ["FreeBSD 10.1*-RELEASE*", "FreeBSD/EC2 10.1*-RELEASE*"] },
+      { name: "owner-id", values: %w{118940168514} },
+      { name: "name", values: ["FreeBSD 10.1*-RELEASE*", "FreeBSD/EC2 10.1*-RELEASE*"] },
     ],
     "freebsd-x86_64" => [
-      { :name => "owner-id", :values => %w{118940168514} },
-      { :name => "name", :values => ["FreeBSD *-RELEASE*", "FreeBSD/EC2 *-RELEASE*"] },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{118940168514} },
+      { name: "name", values: ["FreeBSD *-RELEASE*", "FreeBSD/EC2 *-RELEASE*"] },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "freebsd-10-x86_64" => [
-      { :name => "owner-id", :values => %w{118940168514} },
-      { :name => "name", :values => ["FreeBSD 10*-RELEASE*", "FreeBSD/EC2 10*-RELEASE*"] },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{118940168514} },
+      { name: "name", values: ["FreeBSD 10*-RELEASE*", "FreeBSD/EC2 10*-RELEASE*"] },
+      { name: "architecture", values: %w{x86_64} },
     ],
 
     "ubuntu" => [
-      { :name => "owner-id", :values => %w{099720109477} },
-      { :name => "name", :values => %w{ubuntu/images/*/ubuntu-*-*} },
+      { name: "owner-id", values: %w{099720109477} },
+      { name: "name", values: %w{ubuntu/images/*/ubuntu-*-*} },
     ],
     "ubuntu-14" => [
-      { :name => "owner-id", :values => %w{099720109477} },
-      { :name => "name", :values => %w{ubuntu/images/*/ubuntu-*-14*} },
+      { name: "owner-id", values: %w{099720109477} },
+      { name: "name", values: %w{ubuntu/images/*/ubuntu-*-14*} },
     ],
     "ubuntu-12.04" => [
-      { :name => "owner-id", :values => %w{099720109477} },
-      { :name => "name", :values => %w{ubuntu/images/*/ubuntu-*-12.04*} },
+      { name: "owner-id", values: %w{099720109477} },
+      { name: "name", values: %w{ubuntu/images/*/ubuntu-*-12.04*} },
     ],
     "ubuntu-x86_64" => [
-      { :name => "owner-id", :values => %w{099720109477} },
-      { :name => "name", :values => %w{ubuntu/images/*/ubuntu-*-*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{099720109477} },
+      { name: "name", values: %w{ubuntu/images/*/ubuntu-*-*} },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "ubuntu-14-x86_64" => [
-      { :name => "owner-id", :values => %w{099720109477} },
-      { :name => "name", :values => %w{ubuntu/images/*/ubuntu-*-14*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "owner-id", values: %w{099720109477} },
+      { name: "name", values: %w{ubuntu/images/*/ubuntu-*-14*} },
+      { name: "architecture", values: %w{x86_64} },
     ],
 
     "windows" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-*-RTM-English-*-Base-*
         Windows_Server-*-SP*-English-*-Base-*
         Windows_Server-*-R*_RTM-English-*-Base-*
@@ -241,63 +241,63 @@ describe "Default images for various platforms" do
         Windows_Server-*-English-Full-Base-*} },
     ],
     "windows-2008" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2008-RTM-English-*-Base-*
         Windows_Server-2008-SP*-English-*-Base-*} },
     ],
     "windows-2012" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2012-RTM-English-*-Base-*
         Windows_Server-2012-SP*-English-*-Base-*} },
     ],
     "windows-2012r2" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2012-R2_RTM-English-*-Base-*
         Windows_Server-2012-R2_SP*-English-*-Base-*} },
     ],
     "windows-2012sp1" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2012-SP1-English-*-Base-*} },
     ],
     "windows-2012rtm" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2012-RTM-English-*-Base-*} },
     ],
     "windows-2012r2sp1" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2012-R2_SP1-English-*-Base-*} },
     ],
     "windows-2012r2rtm" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2012-R2_RTM-English-*-Base-*} },
     ],
     "windows-x86_64" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-*-RTM-English-*-Base-*
         Windows_Server-*-SP*-English-*-Base-*
         Windows_Server-*-R*_RTM-English-*-Base-*
         Windows_Server-*-R*_SP*-English-*-Base-*
         Windows_Server-*-English-Full-Base-*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "windows-2012r2-x86_64" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2012-R2_RTM-English-*-Base-*
         Windows_Server-2012-R2_SP*-English-*-Base-*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "windows-server" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-*-RTM-English-*-Base-*
         Windows_Server-*-SP*-English-*-Base-*
         Windows_Server-*-R*_RTM-English-*-Base-*
@@ -305,68 +305,68 @@ describe "Default images for various platforms" do
         Windows_Server-*-English-Full-Base-*} },
     ],
     "windows-server-2012r2-x86_64" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2012-R2_RTM-English-*-Base-*
         Windows_Server-2012-R2_SP*-English-*-Base-*} },
-      { :name => "architecture", :values => %w{x86_64} },
+      { name: "architecture", values: %w{x86_64} },
     ],
     "windows-2016" => [
-      { :name => "owner-alias", :values => %w{amazon} },
-      { :name => "name", :values => %w{
+      { name: "owner-alias", values: %w{amazon} },
+      { name: "name", values: %w{
         Windows_Server-2016-English-Full-Base-*} },
     ],
-  }
+  }.freeze
 
   describe "Platform defaults" do
     PLATFORM_SEARCHES.each do |platform_name, filters|
       context "when platform is #{platform_name}" do
-        let(:image) { FakeImage.new(:name => platform_name.split("-", 2)[0]) }
+        let(:image) { FakeImage.new(name: platform_name.split("-", 2)[0]) }
 
         it "searches for #{filters} and uses the resulting image" do
-          expect(driver.ec2.resource).
-            to receive(:images).with(:filters => filters).and_return([image])
-          expect(driver.ec2.resource).
-            to receive(:image).with(image.id).and_return(image)
+          expect(driver.ec2.resource)
+            .to receive(:images).with(filters: filters).and_return([image])
+          expect(driver.ec2.resource)
+            .to receive(:image).with(image.id).and_return(image)
 
-          instance = new_instance(:platform_name => platform_name)
-          expect(instance.driver.instance_generator.ec2_instance_data[:image_id]).
-            to eq image.id
+          instance = new_instance(platform_name: platform_name)
+          expect(instance.driver.instance_generator.ec2_instance_data[:image_id])
+            .to eq image.id
         end
       end
     end
   end
 
   context "when image_search is provided" do
-    let(:image) { FakeImage.new(:name => "ubuntu") }
-    let(:config) { { :image_search => { :name => "SuperImage" } } }
+    let(:image) { FakeImage.new(name: "ubuntu") }
+    let(:config) { { image_search: { name: "SuperImage" } } }
 
     context "and platform.name is a well known platform name" do
       it "searches for an image id without using the standard filters" do
-        expect(driver.ec2.resource).
-          to receive(:images).
-          with(:filters => [{ :name => "name", :values => %w{SuperImage} }]).
-          and_return([image])
-        expect(driver.ec2.resource).
-          to receive(:image).with(image.id).and_return(image)
+        expect(driver.ec2.resource)
+          .to receive(:images)
+          .with(filters: [{ name: "name", values: %w{SuperImage} }])
+          .and_return([image])
+        expect(driver.ec2.resource)
+          .to receive(:image).with(image.id).and_return(image)
 
-        instance = new_instance(:platform_name => "ubuntu")
-        expect(instance.driver.instance_generator.ec2_instance_data[:image_id]).
-          to eq image.id
+        instance = new_instance(platform_name: "ubuntu")
+        expect(instance.driver.instance_generator.ec2_instance_data[:image_id])
+          .to eq image.id
       end
     end
 
     context "and platform.name is not a well known platform name" do
-      let(:image) { FakeImage.new(:name => "ubuntu") }
+      let(:image) { FakeImage.new(name: "ubuntu") }
       it "does not search for (or find) an image, and informs the user they need to set image_id" do
-        expect(driver.ec2.resource).
-          to receive(:images).
-          with(:filters => [{ :name => "name", :values => %w{SuperImage} }]).
-          and_return([image])
-        expect(driver.ec2.resource).
-          to receive(:image).with(image.id).and_return(image)
+        expect(driver.ec2.resource)
+          .to receive(:images)
+          .with(filters: [{ name: "name", values: %w{SuperImage} }])
+          .and_return([image])
+        expect(driver.ec2.resource)
+          .to receive(:image).with(image.id).and_return(image)
 
-        instance = new_instance(:platform_name => "blarghle")
+        instance = new_instance(platform_name: "blarghle")
         expect(instance.driver.instance_generator.ec2_instance_data[:image_id]).to eq image.id
       end
     end

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -289,8 +289,8 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           :key_name => nil,
           :subnet_id => nil,
           :private_ip_address => nil,
-          :placement => { :availability_zone => "eu-east-1c",
-                          :tenancy => "dedicated" }
+          :placement => { :tenancy => "dedicated",
+                          :availability_zone => "eu-east-1c" }
         )
       end
     end
@@ -331,8 +331,8 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           :key_name => nil,
           :subnet_id => nil,
           :private_ip_address => nil,
-          :placement => { :availability_zone => "eu-east-1c",
-                          :tenancy => "dedicated" }
+          :placement => { :tenancy => "dedicated",
+                          :availability_zone => "eu-east-1c" }
         )
       end
     end

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -273,64 +273,6 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       end
     end
 
-    context "when availability_zone is provided as 'eu-west-1c'" do
-      let(:config) do
-        {
-          :region => "eu-east-1",
-          :availability_zone => "eu-west-1c",
-        }
-      end
-      it "returns that in the instance data" do
-        expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil,
-          :placement => { :availability_zone => "eu-west-1c" }
-        )
-      end
-    end
-
-    context "when availability_zone is provided as 'c'" do
-      let(:config) do
-        {
-          :region => "eu-east-1",
-          :availability_zone => "c",
-        }
-      end
-      it "adds the region to it in the instance data" do
-        expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil,
-          :placement => { :availability_zone => "eu-east-1c" }
-        )
-      end
-    end
-
-    context "when availability_zone is not provided" do
-      let(:config) do
-        {
-          :region => "eu-east-1",
-        }
-      end
-      it "is not added to the instance data" do
-        expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil
-        )
-      end
-    end
-
     context "when availability_zone and tenancy are provided" do
       let(:config) do
         {
@@ -606,6 +548,78 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           :placement => { :availability_zone => "eu-west-1a" },
           :user_data => Base64.encode64("foo")
         )
+      end
+    end
+  end
+
+  describe "#availability_zone" do
+    context "when availability_zone is provided as 'eu-west-1c'" do
+      let(:config) do
+        {
+          :region => "eu-west-1",
+          :availability_zone => "eu-west-1c",
+        }
+      end
+      it "returns that in the instance data" do
+        expect(generator.availability_zone).to eq("eu-west-1c")
+      end
+    end
+
+    context "when availability_zone is provided as 'c'" do
+      let(:config) do
+        {
+          :region => "eu-east-1",
+          :availability_zone => "c",
+        }
+      end
+      it "adds the region to it in the instance data" do
+        expect(generator.availability_zone).to eq("eu-east-1c")
+      end
+    end
+
+    context "when availability_zone is not provided" do
+      let(:config) do
+        {
+          :region => "eu-east-1",
+        }
+      end
+      it "is not added to the instance data" do
+        expect(generator.availability_zone).to eq(nil)
+      end
+    end
+  end
+
+  describe "#placement" do
+    context "when availability_zone and tenancy are set" do
+      let(:config) do
+        {
+          :tenancy => "host",
+          :availability_zone => "eu-west-1c",
+        }
+      end
+      it "returns a hash with az and tenancy" do
+        expect(generator.placement).to eq({
+          :availability_zone => "eu-west-1c",
+          :tenancy => "host",
+          })
+      end
+    end
+
+    context "when neither availability_zone and tenancy are set" do
+      let(:config) do
+        {}
+      end
+      it "returns an empty hash" do
+        expect(generator.placement).to eq({})
+      end
+    end
+
+    context "when just availability zone is set" do
+      let(:config) do
+        { :availability_zone => "eu-west-1c" }
+      end
+      it "returns a hash with just the AZ" do
+        expect(generator.placement).to eq(:availability_zone => "eu-west-1c")
       end
     end
   end

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -21,7 +21,7 @@ require "kitchen/driver/aws/instance_generator"
 require "kitchen/driver/aws/client"
 require "tempfile"
 require "base64"
-require "aws-sdk"
+require "aws-sdk-ec2"
 
 describe Kitchen::Driver::Aws::InstanceGenerator do
 

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -23,7 +23,6 @@ require "kitchen/transport/dummy"
 require "kitchen/verifier/dummy"
 
 describe Kitchen::Driver::Ec2 do
-
   let(:logged_output) { StringIO.new }
   let(:logger)        { Logger.new(logged_output) }
   let(:config) do
@@ -793,5 +792,4 @@ describe Kitchen::Driver::Ec2 do
       end
     end
   end
-
 end

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -27,21 +27,21 @@ describe Kitchen::Driver::Ec2 do
   let(:logger)        { Logger.new(logged_output) }
   let(:config) do
     {
-      :aws_ssh_key_id => "key",
-      :image_id => "ami-1234567",
-      :block_duration_minutes => 60,
-      :subnet_id => "subnet-1234",
-      :security_group_ids => ["sg-56789"],
+      aws_ssh_key_id: "key",
+      image_id: "ami-1234567",
+      block_duration_minutes: 60,
+      subnet_id: "subnet-1234",
+      security_group_ids: ["sg-56789"],
     }
   end
-  let(:platform)      { Kitchen::Platform.new(:name => "fooos-99") }
+  let(:platform)      { Kitchen::Platform.new(name: "fooos-99") }
   let(:transport)     { Kitchen::Transport::Dummy.new }
   let(:provisioner)   { Kitchen::Provisioner::Dummy.new }
   let(:generator)     { instance_double(Kitchen::Driver::Aws::InstanceGenerator) }
   # There is too much name overlap I let creep in - my `client` is actually
   # a wrapper around the actual ec2 client
   let(:actual_client) { double("actual ec2 client") }
-  let(:client)        { double(Kitchen::Driver::Aws::Client, :client => actual_client) }
+  let(:client)        { double(Kitchen::Driver::Aws::Client, client: actual_client) }
   let(:server) { double("aws server object") }
   let(:state) { {} }
 
@@ -50,11 +50,11 @@ describe Kitchen::Driver::Ec2 do
   let(:instance) do
     instance_double(
       Kitchen::Instance,
-      :logger => logger,
-      :transport => transport,
-      :provisioner => provisioner,
-      :platform => platform,
-      :to_str => "str"
+      logger: logger,
+      transport: transport,
+      provisioner: provisioner,
+      platform: platform,
+      to_str: "str"
     )
   end
 
@@ -76,7 +76,7 @@ describe Kitchen::Driver::Ec2 do
 
   describe "default_config" do
     context "Windows" do
-      let(:resource) { instance_double(::Aws::EC2::Resource, :image => image) }
+      let(:resource) { instance_double(::Aws::EC2::Resource, image: image) }
       before do
         allow(driver).to receive(:windows_os?).and_return(true)
         allow(client).to receive(:resource).and_return(resource)
@@ -84,7 +84,7 @@ describe Kitchen::Driver::Ec2 do
       end
       context "Windows 2016" do
         let(:image) do
-          FakeImage.new(:name => "Windows_Server-2016-English-Full-Base-2017.01.11")
+          FakeImage.new(name: "Windows_Server-2016-English-Full-Base-2017.01.11")
         end
         it "sets :user_data to something" do
           expect(driver[:user_data]).to include
@@ -93,7 +93,7 @@ describe Kitchen::Driver::Ec2 do
       end
       context "Windows 2012R2" do
         let(:image) do
-          FakeImage.new(:name => "Windows_Server-2012-R2_RTM-English-64Bit-Base-2017.01.11")
+          FakeImage.new(name: "Windows_Server-2012-R2_RTM-English-64Bit-Base-2017.01.11")
         end
         it "sets :user_data to something" do
           expect(driver[:user_data]).to include
@@ -110,10 +110,10 @@ describe Kitchen::Driver::Ec2 do
     let(:private_ip_address) { nil }
     let(:server) do
       double("server",
-        :public_dns_name => public_dns_name,
-        :private_dns_name => private_dns_name,
-        :public_ip_address => public_ip_address,
-        :private_ip_address => private_ip_address
+        public_dns_name: public_dns_name,
+        private_dns_name: private_dns_name,
+        public_ip_address: public_ip_address,
+        private_ip_address: private_ip_address
       )
     end
 
@@ -215,7 +215,7 @@ describe Kitchen::Driver::Ec2 do
 
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
-      expect(client).to receive(:create_instance).with(:min_count => 1, :max_count => 1)
+      expect(client).to receive(:create_instance).with(min_count: 1, max_count: 1)
       driver.submit_server
     end
   end
@@ -228,10 +228,10 @@ describe Kitchen::Driver::Ec2 do
 
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return(
-        :instance_initiated_shutdown_behavior => "terminate"
+        instance_initiated_shutdown_behavior: "terminate"
       )
       expect(client).to receive(:create_instance).with(
-        :min_count => 1, :max_count => 1, :instance_initiated_shutdown_behavior => "terminate"
+        min_count: 1, max_count: 1, instance_initiated_shutdown_behavior: "terminate"
       )
       driver.submit_server
     end
@@ -240,7 +240,7 @@ describe Kitchen::Driver::Ec2 do
   describe "#submit_spot" do
     let(:state) { {} }
     let(:response) do
-      { :spot_instance_requests => [{ :spot_instance_request_id => "id" }] }
+      { spot_instance_requests: [{ spot_instance_request_id: "id" }] }
     end
 
     before do
@@ -251,15 +251,15 @@ describe Kitchen::Driver::Ec2 do
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
       expect(actual_client).to receive(:request_spot_instances).with(
-        :spot_price => "",
-        :launch_specification => {},
-        :valid_until => Time.now + (config[:retryable_tries] * config[:retryable_sleep]),
-        :block_duration_minutes => 60
+        spot_price: "",
+        launch_specification: {},
+        valid_until: Time.now + (config[:retryable_tries] * config[:retryable_sleep]),
+        block_duration_minutes: 60
       ).and_return(response)
       expect(actual_client).to receive(:wait_until)
       expect(client).to receive(:get_instance_from_spot_request).with("id")
       driver.submit_spot(state)
-      expect(state).to eq(:spot_request_id => "id")
+      expect(state).to eq(spot_request_id: "id")
     end
   end
 
@@ -273,11 +273,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with standard string tags" do
       it "tags the server" do
-        config[:tags] = { :key1 => "value1", :key2 => "value2" }
+        config[:tags] = { key1: "value1", key2: "value2" }
         expect(server).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "value2" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "value2" },
           ]
         )
         driver.tag_server(server)
@@ -286,11 +286,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with a tag that includes a Integer value" do
       it "tags the server" do
-        config[:tags] = { :key1 => "value1", :key2 => 1 }
+        config[:tags] = { key1: "value1", key2: 1 }
         expect(server).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "1" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "1" },
           ]
         )
         driver.tag_server(server)
@@ -299,11 +299,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with a tag that includes a Nil value" do
       it "tags the server" do
-        config[:tags] = { :key1 => "value1", :key2 => nil }
+        config[:tags] = { key1: "value1", key2: nil }
         expect(server).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "" },
           ]
         )
         driver.tag_server(server)
@@ -318,11 +318,11 @@ describe Kitchen::Driver::Ec2 do
     end
     context "with standard string tags" do
       it "tags the instance volumes" do
-        config[:tags] = { :key1 => "value1", :key2 => "value2" }
+        config[:tags] = { key1: "value1", key2: "value2" }
         expect(volume).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "value2" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "value2" },
           ]
         )
         driver.tag_volumes(server)
@@ -331,11 +331,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with a tag that includes a Integer value" do
       it "tags the instance volumes" do
-        config[:tags] = { :key1 => "value1", :key2 => 2 }
+        config[:tags] = { key1: "value1", key2: 2 }
         expect(volume).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "2" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "2" },
           ]
         )
         driver.tag_volumes(server)
@@ -344,11 +344,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with a tag that includes a Nil value" do
       it "tags the instance volumes" do
-        config[:tags] = { :key1 => "value1", :key2 => nil }
+        config[:tags] = { key1: "value1", key2: nil }
         expect(volume).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "" },
           ]
         )
         driver.tag_volumes(server)
@@ -441,9 +441,9 @@ describe Kitchen::Driver::Ec2 do
     let(:aws_instance) { double("aws instance") }
     let(:server_id) { "server_id" }
     let(:encrypted_password) { "alksdofw" }
-    let(:data) { double("data", :password_data => encrypted_password) }
+    let(:data) { double("data", password_data: encrypted_password) }
     let(:password) { "password" }
-    let(:transport) { { :ssh_key => "foo" } }
+    let(:transport) { { ssh_key: "foo" } }
 
     before do
       state[:server_id] = server_id
@@ -456,11 +456,11 @@ describe Kitchen::Driver::Ec2 do
 
     it "fetches and decrypts the windows password" do
       expect(server).to receive_message_chain("client.get_password_data").with(
-        :instance_id => server_id
+        instance_id: server_id
       ).and_return(data)
-      expect(server).to receive(:decrypt_windows_password).
-        with(File.expand_path("foo")).
-        and_return(password)
+      expect(server).to receive(:decrypt_windows_password)
+        .with(File.expand_path("foo"))
+        .and_return(password)
       driver.fetch_windows_admin_password(server, state)
     end
 
@@ -521,7 +521,7 @@ describe Kitchen::Driver::Ec2 do
   end
 
   describe "#create" do
-    let(:server) { double("aws server object", :id => id, :image_id => "ami-3f807145") }
+    let(:server) { double("aws server object", id: id, image_id: "ami-3f807145") }
     let(:id) { "i-12345" }
 
     it "returns if the instance is already created" do
@@ -529,7 +529,7 @@ describe Kitchen::Driver::Ec2 do
       expect(driver.create(state)).to eq(nil)
     end
 
-    image_data = Aws::EC2::Types::Image.new(:root_device_type => "ebs")
+    image_data = Aws::EC2::Types::Image.new(root_device_type: "ebs")
     ec2_stub = Aws::EC2::Types::DescribeImagesResult.new
     ec2_stub.images = [image_data]
 
@@ -541,7 +541,7 @@ describe Kitchen::Driver::Ec2 do
         expect(driver).to receive(:tag_volumes).with(server)
         expect(driver).to receive(:wait_until_volumes_ready).with(server, state)
         expect(driver).to receive(:wait_until_ready).with(server, state)
-        allow(actual_client).to receive(:describe_images).with({ :image_ids => [server.image_id] }).and_return(ec2_stub)
+        allow(actual_client).to receive(:describe_images).with({ image_ids: [server.image_id] }).and_return(ec2_stub)
         expect(transport).to receive_message_chain("connection.wait_until_ready")
         driver.create(state)
         expect(state[:server_id]).to eq(id)
@@ -549,7 +549,7 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context "chef provisioner" do
-      let(:provisioner) { double("chef provisioner", :name => "chef_solo") }
+      let(:provisioner) { double("chef provisioner", name: "chef_solo") }
 
       before do
         expect(driver).to receive(:create_ec2_json).with(state)
@@ -735,7 +735,7 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context "when state has a normal server_id" do
-      let(:state) { { :server_id => "id", :hostname => "name" } }
+      let(:state) { { server_id: "id", hostname: "name" } }
 
       context "the server is already destroyed" do
         it "does nothing" do
@@ -755,14 +755,14 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context "when state has a spot request" do
-      let(:state) { { :server_id => "id", :hostname => "name", :spot_request_id => "spot" } }
+      let(:state) { { server_id: "id", hostname: "name", spot_request_id: "spot" } }
 
       it "destroys the server" do
         expect(client).to receive(:get_instance).with("id").and_return(server)
         expect(instance).to receive_message_chain("transport.connection.close")
         expect(server).to receive(:terminate)
         expect(actual_client).to receive(:cancel_spot_instance_requests).with(
-          :spot_instance_request_ids => ["spot"]
+          spot_instance_request_ids: ["spot"]
         )
         driver.destroy(state)
         expect(state).to eq({})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,6 +101,6 @@ RSpec.configure do |config|
   config.expose_dsl_globally = true
 end
 
-require "aws-sdk"
+require "aws-sdk-ec2"
 # https://ruby.awsblog.com/post/Tx15V81MLPR8D73/Client-Response-Stubs
 Aws.config[:stub_responses] = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,7 +99,6 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.expose_dsl_globally = true
-
 end
 
 require "aws-sdk"


### PR DESCRIPTION
ec2_instance_data is pretty much what every Rubocop warning was written to warn against. It's grown organically over the years as new options were added to AWS and it's gotten pretty huge lately. Breaking it up should make it easier to test things and much easier to read through the code.