### PR TITLE
Add copyrights, license headers and remove old rubocop comments

### DIFF
--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -2,7 +2,8 @@
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #
-# Copyright (C) 2015, Fletcher Nichol
+# Copyright:: 2016-2018, Chef Software, Inc.
+# Copyright:: 2015-2018, Fletcher Nichol
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -32,7 +32,7 @@ module Kitchen
       # @author Tyler Ball <tball@chef.io>
       class Client
 
-        def initialize( # rubocop:disable Metrics/ParameterLists
+        def initialize(
           region,
           profile_name = "default",
           http_proxy = nil,
@@ -47,8 +47,6 @@ module Kitchen
           )
           ::Aws.config.update(:retry_limit => retry_limit) unless retry_limit.nil?
         end
-
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def create_instance(options)
           resource.create_instances(options)[0]

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -2,7 +2,8 @@
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #
-# Copyright (C) 2015, Fletcher Nichol
+# Copyright:: 2016-2018, Chef Software, Inc.
+# Copyright:: 2015-2018, Fletcher Nichol
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/kitchen/driver/aws/standard_platform.rb
+++ b/lib/kitchen/driver/aws/standard_platform.rb
@@ -1,3 +1,19 @@
+#
+# Copyright:: 2016-2018, Chef Software, Inc.
+# Copyright:: 2015-2018, Fletcher Nichol
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Kitchen
   module Driver
     class Aws

--- a/lib/kitchen/driver/aws/standard_platform/amazon.rb
+++ b/lib/kitchen/driver/aws/standard_platform/amazon.rb
@@ -1,3 +1,18 @@
+#
+# Copyright:: 2016-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "kitchen/driver/aws/standard_platform"
 
 module Kitchen

--- a/lib/kitchen/driver/aws/standard_platform/centos.rb
+++ b/lib/kitchen/driver/aws/standard_platform/centos.rb
@@ -1,3 +1,18 @@
+#
+# Copyright:: 2016-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "kitchen/driver/aws/standard_platform"
 
 module Kitchen

--- a/lib/kitchen/driver/aws/standard_platform/debian.rb
+++ b/lib/kitchen/driver/aws/standard_platform/debian.rb
@@ -1,3 +1,18 @@
+#
+# Copyright:: 2016-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "kitchen/driver/aws/standard_platform"
 
 module Kitchen

--- a/lib/kitchen/driver/aws/standard_platform/fedora.rb
+++ b/lib/kitchen/driver/aws/standard_platform/fedora.rb
@@ -1,3 +1,18 @@
+#
+# Copyright:: 2016-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "kitchen/driver/aws/standard_platform"
 
 module Kitchen

--- a/lib/kitchen/driver/aws/standard_platform/freebsd.rb
+++ b/lib/kitchen/driver/aws/standard_platform/freebsd.rb
@@ -1,3 +1,18 @@
+#
+# Copyright:: 2016-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "kitchen/driver/aws/standard_platform"
 
 module Kitchen

--- a/lib/kitchen/driver/aws/standard_platform/rhel.rb
+++ b/lib/kitchen/driver/aws/standard_platform/rhel.rb
@@ -1,3 +1,18 @@
+#
+# Copyright:: 2016-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "kitchen/driver/aws/standard_platform"
 
 module Kitchen

--- a/lib/kitchen/driver/aws/standard_platform/ubuntu.rb
+++ b/lib/kitchen/driver/aws/standard_platform/ubuntu.rb
@@ -1,3 +1,18 @@
+#
+# Copyright:: 2016-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "kitchen/driver/aws/standard_platform"
 
 module Kitchen

--- a/lib/kitchen/driver/aws/standard_platform/windows.rb
+++ b/lib/kitchen/driver/aws/standard_platform/windows.rb
@@ -1,3 +1,18 @@
+#
+# Copyright:: 2016-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "kitchen/driver/aws/standard_platform"
 
 module Kitchen

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -46,7 +46,7 @@ module Kitchen
     # Amazon EC2 driver for Test Kitchen.
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
-    class Ec2 < Kitchen::Driver::Base # rubocop:disable Metrics/ClassLength
+    class Ec2 < Kitchen::Driver::Base
 
       kitchen_driver_api_version 2
 
@@ -177,7 +177,7 @@ module Kitchen
         end
       end
 
-      def create(state) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def create(state)
         return if state[:server_id]
         update_username(state)
 
@@ -393,7 +393,7 @@ module Kitchen
         ec2.create_instance(instance_data)
       end
 
-      def submit_spot(state) # rubocop:disable Metrics/AbcSize
+      def submit_spot(state)
         debug("Creating EC2 Spot Instance..")
 
         spot_request_id = create_spot_request
@@ -517,7 +517,6 @@ module Kitchen
         end
       end
 
-      # rubocop:disable Lint/UnusedBlockArgument
       def fetch_windows_admin_password(server, state)
         wait_with_destroy(server, state, "to fetch windows admin password") do |aws_instance|
           enc = server.client.get_password_data(
@@ -532,7 +531,6 @@ module Kitchen
         state[:password] = pass
         info("Retrieved Windows password for instance <#{state[:server_id]}>.")
       end
-      # rubocop:enable Lint/UnusedBlockArgument
 
       def with_request_limit_backoff(state)
         retries = 0
@@ -589,7 +587,6 @@ module Kitchen
         instance.provisioner[:sudo] ? instance.provisioner[:sudo_command].to_s : ""
       end
 
-      # rubocop:disable Metrics/MethodLength, Metrics/LineLength
       def create_ec2_json(state)
         if windows_os?
           cmd = "New-Item -Force C:\\chef\\ohai\\hints\\ec2.json -ItemType File"
@@ -654,7 +651,6 @@ module Kitchen
         </powershell>
         EOH
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/LineLength
 
       def show_chosen_image
         # Print some debug stuff

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -2,7 +2,8 @@
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #
-# Copyright (C) 2015, Fletcher Nichol
+# Copyright:: 2016-2018, Chef Software, Inc.
+# Copyright:: 2015-2018, Fletcher Nichol
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -2,7 +2,8 @@
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #
-# Copyright (C) 2012, Fletcher Nichol
+# Copyright:: 2016-2018, Chef Software, Inc.
+# Copyright:: 2012-2018, Fletcher Nichol
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/kitchen/driver/ec2/client_spec.rb
+++ b/spec/kitchen/driver/ec2/client_spec.rb
@@ -2,7 +2,8 @@
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #
-# Copyright (C) 2015, Fletcher Nichol
+# Copyright:: 2015-2018, Fletcher Nichol
+# Copyright:: 2016-2018, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/kitchen/driver/ec2/image_selection_spec.rb
+++ b/spec/kitchen/driver/ec2/image_selection_spec.rb
@@ -1,3 +1,19 @@
+#
+# Copyright:: 2015-2018, Fletcher Nichol
+# Copyright:: 2016-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "kitchen/driver/ec2"
 require "kitchen/provisioner/dummy"
 require "kitchen/transport/dummy"

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -2,7 +2,8 @@
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #
-# Copyright (C) 2015, Fletcher Nichol
+# Copyright:: 2015-2018, Fletcher Nichol
+# Copyright:: 2016-2018, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -2,7 +2,8 @@
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #
-# Copyright (C) 2015, Fletcher Nichol
+# Copyright:: 2015-2018, Fletcher Nichol
+# Copyright:: 2016-2018, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,8 @@
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #
-# Copyright (C) 2015, Fletcher Nichol
+# Copyright:: 2015-2018, Fletcher Nichol
+# Copyright:: 2016-2018, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Make sure we have a license everywhere with up to date copyrights. Also yank out all the old rubocop configs from before we switched to chefstyle.