### PR TITLE
Fix handling of nil/Integer tags and add logging if improper format is used

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -453,7 +453,7 @@ module Kitchen
       def tag_server(server)
         if config[:tags] && !config[:tags].empty?
           tags = config[:tags].map do |k, v|
-            { :key => k, :value => v }
+            { :key => k, :value => v.to_s } # val must be a string
           end
           server.create_tags(:tags => tags)
         end

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -187,14 +187,6 @@ module Kitchen
             "on each line. Example: {:foo => 'bar', :bar => 'foo'}"
           exit!
         end
-
-        # see if the passes hash has any nil values
-        nils = val.select { |k, v| v.nil? }
-        unless nils.empty?
-          warn "AWS instance tags cannot be nil. The following tag(s) " \
-            "had no value specified: #{nils.keys.join(', ')}"
-          exit!
-        end
       end
 
       def create(state)
@@ -453,7 +445,10 @@ module Kitchen
       def tag_server(server)
         if config[:tags] && !config[:tags].empty?
           tags = config[:tags].map do |k, v|
-            { :key => k, :value => v.to_s } # val must be a string
+            # we convert the value to a string because
+            # nils should be passed as an empty String
+            # and Integers need to be represented as Strings
+            { :key => k, :value => v.to_s }
           end
           server.create_tags(:tags => tags)
         end
@@ -462,7 +457,7 @@ module Kitchen
       def tag_volumes(server)
         if config[:tags] && !config[:tags].empty?
           tags = config[:tags].map do |k, v|
-            { :key => k, :value => v }
+            { :key => k, :value => v.to_s }
           end
           server.volumes.each do |volume|
             volume.create_tags(:tags => tags)

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -178,6 +178,25 @@ module Kitchen
         end
       end
 
+      # empty keys cause failures when tagging and they make no sense
+      validations[:tags] = lambda do |attr, val, _driver|
+        # if someone puts the tags each on their own line it's an array not a hash
+        # @todo we should probably just do the right thing and support this format
+        if val.class == Array
+          warn "AWS instance tags must be specified as a single hash, not a tag " \
+            "on each line. Example: {:foo => 'bar', :bar => 'foo'}"
+          exit!
+        end
+
+        # see if the passes hash has any nil values
+        nils = val.select { |k, v| v.nil? }
+        unless nils.empty?
+          warn "AWS instance tags cannot be nil. The following tag(s) " \
+            "had no value specified: #{nils.keys.join(', ')}"
+          exit!
+        end
+      end
+
       def create(state)
         return if state[:server_id]
         update_username(state)

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -265,19 +265,50 @@ describe Kitchen::Driver::Ec2 do
   end
 
   describe "#tag_server" do
-    it "tags the server" do
-      config[:tags] = { :key1 => :value1, :key2 => :value2 }
-      expect(server).to receive(:create_tags).with(
-        :tags => [
-          { :key => :key1, :value => :value1 },
-          { :key => :key2, :value => :value2 },
-        ]
-      )
-      driver.tag_server(server)
+    context "with no tags specified" do
+      it "does not raise" do
+        config[:tags] = nil
+        expect { driver.tag_server(server) }.not_to raise_error
+      end
     end
-    it "does not raise" do
-      config[:tags] = nil
-      expect { driver.tag_server(server) }.not_to raise_error
+
+    context "with standard string tags" do
+      it "tags the server" do
+        config[:tags] = { :key1 => "value1", :key2 => "value2" }
+        expect(server).to receive(:create_tags).with(
+          :tags => [
+            { :key => :key1, :value => "value1" },
+            { :key => :key2, :value => "value2" },
+          ]
+        )
+        driver.tag_server(server)
+      end
+    end
+
+    context "with a tag that includes a Integer value" do
+      it "tags the server" do
+        config[:tags] = { :key1 => "value1", :key2 => 1 }
+        expect(server).to receive(:create_tags).with(
+          :tags => [
+            { :key => :key1, :value => "value1" },
+            { :key => :key2, :value => "1" },
+          ]
+        )
+        driver.tag_server(server)
+      end
+    end
+
+    context "with a tag that includes a Nil value" do
+      it "tags the server" do
+        config[:tags] = { :key1 => "value1", :key2 => nil }
+        expect(server).to receive(:create_tags).with(
+          :tags => [
+            { :key => :key1, :value => "value1" },
+            { :key => :key2, :value => "" },
+          ]
+        )
+        driver.tag_server(server)
+      end
     end
   end
 
@@ -286,15 +317,43 @@ describe Kitchen::Driver::Ec2 do
     before do
       allow(server).to receive(:volumes).and_return([volume])
     end
-    it "tags the instance volumes" do
-      config[:tags] = { :key1 => :value1, :key2 => :value2 }
-      expect(volume).to receive(:create_tags).with(
-        :tags => [
-          { :key => :key1, :value => :value1 },
-          { :key => :key2, :value => :value2 },
-        ]
-      )
-      driver.tag_volumes(server)
+    context "with standard string tags" do
+      it "tags the instance volumes" do
+        config[:tags] = { :key1 => "value1", :key2 => "value2" }
+        expect(volume).to receive(:create_tags).with(
+          :tags => [
+            { :key => :key1, :value => "value1" },
+            { :key => :key2, :value => "value2" },
+          ]
+        )
+        driver.tag_volumes(server)
+      end
+    end
+
+    context "with a tag that includes a Integer value" do
+      it "tags the instance volumes" do
+        config[:tags] = { :key1 => "value1", :key2 => 2 }
+        expect(volume).to receive(:create_tags).with(
+          :tags => [
+            { :key => :key1, :value => "value1" },
+            { :key => :key2, :value => "2" },
+          ]
+        )
+        driver.tag_volumes(server)
+      end
+    end
+
+    context "with a tag that includes a Nil value" do
+      it "tags the instance volumes" do
+        config[:tags] = { :key1 => "value1", :key2 => nil }
+        expect(volume).to receive(:create_tags).with(
+          :tags => [
+            { :key => :key1, :value => "value1" },
+            { :key => :key2, :value => "" },
+          ]
+        )
+        driver.tag_volumes(server)
+      end
     end
   end
 


### PR DESCRIPTION
Previous bugs:

- Tag values in AWS can't be Integers, but YAML makes it easy to pass an integer so lets convert those to Strings.
- If you didn't read the example you would probably think 1 tag per line which is incorrect. Lets throw a warning when we see an array instead of a hash, which indicates someone did this.
- If you want to pass a nil value tag you have to do it as an empty string so we need to convert Nils to Strings too.

Signed-off-by: Tim Smith <tsmith@chef.io>