### PR TITLE
Allow 'host' type tenancy & add proper validation warnings

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -95,7 +95,7 @@ module Kitchen
             i[:placement] = { :availability_zone => availability_zone.downcase }
           end
           tenancy = config[:tenancy]
-          if tenancy && %w{default dedicated}.include?(tenancy)
+          if tenancy
             if i.key?(:placement)
               i[:placement][:tenancy] = tenancy
             else
@@ -138,7 +138,7 @@ module Kitchen
             i[:placement] = { :availability_zone => availability_zone.downcase }
           end
           tenancy = config[:tenancy]
-          if tenancy && %w{default dedicated}.include?(tenancy)
+          if tenancy
             if i.key?(:placement)
               i[:placement][:tenancy] = tenancy
             else

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -144,6 +144,15 @@ module Kitchen
         end
       end
 
+      # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html
+      validations[:tenancy] = lambda do |attr, val, _driver|
+        unless %w{default host dedicated}.include?(val)
+          warn "'#{val}' is an invalid value for option '#{attr}'. " \
+            "Valid values are 'default', 'host', or 'dedicated'."
+          exit!
+        end
+      end
+
       # The access key/secret are now using the priority list AWS uses
       # Providing these inside the .kitchen.yml is no longer recommended
       validations[:aws_access_key_id] = lambda do |attr, val, _driver|

--- a/spec/kitchen/driver/ec2/instance_generator_spec.rb
+++ b/spec/kitchen/driver/ec2/instance_generator_spec.rb
@@ -337,25 +337,6 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       end
     end
 
-    context "when tenancy is not supported" do
-      let(:config) do
-        {
-          :region => "eu-east-1",
-          :tenancy => "ephemeral",
-        }
-      end
-      it "is not added to the instance data" do
-        expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil
-        )
-      end
-    end
-
     context "when availability_zone and tenancy are provided" do
       let(:config) do
         {
@@ -394,25 +375,6 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           :subnet_id => nil,
           :private_ip_address => nil,
           :placement => { :tenancy => "default" }
-        )
-      end
-    end
-
-    context "when tenancy is not supported" do
-      let(:config) do
-        {
-          :region => "eu-east-1",
-          :tenancy => "ephemeral",
-        }
-      end
-      it "is not added to the instance data" do
-        expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil
         )
       end
     end


### PR DESCRIPTION
Do this in a validation warning so someone actually knows what the value should be. Right now we'd just silently skip it if someone provided host, which is a pretty bad experience.

Signed-off-by: Tim Smith <tsmith@chef.io>