### PR TITLE
Don't create security group if security_group_filter is set

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -61,6 +61,7 @@ module Kitchen
       end
       default_config :ebs_optimized,      false
       default_config :security_group_ids, nil
+      default_config :security_group_filter, nil
       default_config :tags, "created-by" => "test-kitchen"
       default_config :user_data do |driver|
         if driver.windows_os?
@@ -210,7 +211,7 @@ module Kitchen
         END
 
         # If no security group IDs are specified, create one automatically.
-        unless config[:security_group_ids]
+        unless config[:security_group_ids] || config[:security_group_filter]
           create_security_group(state)
           config[:security_group_ids] = [state[:auto_security_group_id]]
         end

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -646,6 +646,18 @@ describe Kitchen::Driver::Ec2 do
       end
     end
 
+    context "with no security group but filter specified" do
+      before do
+        config.delete(:security_group_ids)
+        config[:security_group_filter] = { tag: "SomeTag", value: "SomeValue" }
+        expect(driver).not_to receive(:create_security_group)
+        expect(driver).to receive(:submit_server).and_return(server)
+        allow(instance).to receive(:name).and_return("instance_name")
+      end
+
+      include_examples "common create"
+    end
+
     context "with no key pair configured" do
       before do
         config[:kitchen_root] = "/kitchen"


### PR DESCRIPTION
If we specify a `security_group_filter` and no `security_group_id` the filter will be ignored and a default `security_group` will be created. This PR should fix this issue.