### PR TITLE
Fix error behavior when security_group_filter is set but no security group found for those tags

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -62,19 +62,21 @@ module Kitchen
           end
 
           if config[:security_group_ids].nil? && config[:security_group_filter]
-            config[:security_group_ids] = [::Aws::EC2::Client.
-              new(:region => config[:region]).describe_security_groups(
+            security_group = ::Aws::EC2::Client.
+                new(:region => config[:region]).describe_security_groups(
                 :filters => [
-                  {
-                    :name   => "tag:#{config[:security_group_filter][:tag]}",
-                    :values => [config[:security_group_filter][:value]],
-                  },
+                    {
+                        :name => "tag:#{config[:security_group_filter][:tag]}",
+                        :values => [config[:security_group_filter][:value]],
+                    },
                 ]
-              )[0][0].group_id]
+            )[0][0]
 
-            if config[:security_group_ids].nil?
-              raise "The group tagged '#{config[:security_group_filter][:tag]}\
-              #{config[:security_group_filter][:value]}' does not exist!"
+            if security_group
+              config[:security_group_ids] = [security_group.group_id]
+            else
+              raise "The group tagged '#{config[:security_group_filter][:tag]} " +
+                "#{config[:security_group_filter][:value]}' does not exist!"
             end
           end
 


### PR DESCRIPTION
Currently, when `security_group_filter` does not match a security group, we get an exception: 

```
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [undefined method `group_id' for nil:NilClass] on default-centos-7
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

This PR catches this case to provide a meaningful error message.