### PR TITLE
Fix dynamic key creation

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -785,10 +785,9 @@ module Kitchen
         resp = ec2.client.create_key_pair(key_name: "kitchen-#{name_parts.join('-')}")
         state[:auto_key_id] = resp.key_name
         info("Created automatic key pair #{state[:auto_key_id]}")
-        # Write the key out, but safely hence the weird sysopen.
+        # Write the key out with safe permissions
         key_path = "#{config[:kitchen_root]}/.kitchen/#{instance.name}.pem"
-        key_fd = File.sysopen(key_path, File::WRONLY | File::CREAT | File::EXCL, 00600)
-        File.open(key_fd) do |f|
+        File.open(key_path, File::WRONLY | File::CREAT | File::EXCL, 00600) do |f|
           f.write(resp.key_material)
         end
         # Inject the key into the state to be used by the SSH transport, or for

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -507,12 +507,9 @@ describe Kitchen::Driver::Ec2 do
         allow(instance).to receive(:name).and_return("instance_name")
 
         expect(actual_client).to receive(:create_key_pair).with(key_name: /kitchen-/).and_return(double(key_name: "expected-key-name", key_material: "RSA PRIVATE KEY"))
-        fake_fd = double()
         fake_file = double()
-        allow(File).to receive(:sysopen).and_call_original
-        expect(File).to receive(:sysopen).with("/kitchen/.kitchen/instance_name.pem", kind_of(Numeric), kind_of(Numeric)).and_return(fake_fd)
         allow(File).to receive(:open).and_call_original
-        expect(File).to receive(:open).with(fake_fd).and_yield(fake_file)
+        expect(File).to receive(:open).with("/kitchen/.kitchen/instance_name.pem", kind_of(Numeric), kind_of(Numeric)).and_yield(fake_file)
         expect(fake_file).to receive(:write).with("RSA PRIVATE KEY")
       end
 


### PR DESCRIPTION
Was seeing a weird issue where Ruby was trying to write to the file before it had actually been created on the file system.... Lost the error output, but it was something along the lines of `File not open for writing`

Moving this all into one code block has resolved the issue.
