### PR TITLE
Require Ruby 2.3 and aws-sdk-ec2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,9 @@ RuboCop::RakeTask.new(:style) do |task|
 end
 
 desc "Run all quality tasks"
-task :quality => [:style, :stats]
+task quality: [:style, :stats]
 
 require "yard"
 YARD::Rake::YardocTask.new
+
+task default: [:test, :quality]

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -16,12 +16,12 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^lib/)
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.2.2"
+  gem.required_ruby_version = ">= 2.3"
 
   gem.add_dependency "test-kitchen", ">= 1.4.1", "< 3"
   gem.add_dependency "excon"
   gem.add_dependency "multi_json"
-  gem.add_dependency "aws-sdk", "~> 2"
+  gem.add_dependency "aws-sdk-ec2", "~> 1.0"
   gem.add_dependency "retryable", "~> 2.0"
 
   gem.add_development_dependency "rspec",     "~> 3.2"

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "aws-sdk"
+require "aws-sdk-ec2"
 require "aws-sdk-core/credentials"
 require "aws-sdk-core/shared_credentials"
 require "aws-sdk-core/instance_profile_credentials"

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -41,12 +41,12 @@ module Kitchen
           ssl_verify_peer = true
         )
           ::Aws.config.update(
-            :region => region,
-            :profile => profile_name,
-            :http_proxy => http_proxy,
-            :ssl_verify_peer => ssl_verify_peer
+            region: region,
+            profile: profile_name,
+            http_proxy: http_proxy,
+            ssl_verify_peer: ssl_verify_peer
           )
-          ::Aws.config.update(:retry_limit => retry_limit) unless retry_limit.nil?
+          ::Aws.config.update(retry_limit: retry_limit) unless retry_limit.nil?
         end
 
         def create_instance(options)
@@ -59,9 +59,9 @@ module Kitchen
 
         def get_instance_from_spot_request(request_id)
           resource.instances(
-            :filters => [{
-              :name => "spot-instance-request-id",
-              :values => [request_id],
+            filters: [{
+              name: "spot-instance-request-id",
+              values: [request_id],
             }]
           ).to_a[0]
         end

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 require "base64"
-require "aws-sdk"
+require "aws-sdk-ec2"
 
 module Kitchen
 

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -45,12 +45,12 @@ module Kitchen
           # Support for looking up security group id and subnet id using tags.
 
           if config[:subnet_id].nil? && config[:subnet_filter]
-            config[:subnet_id] = ::Aws::EC2::Client.
-              new(:region => config[:region]).describe_subnets(
-                :filters => [
+            config[:subnet_id] = ::Aws::EC2::Client
+              .new(region: config[:region]).describe_subnets(
+                filters: [
                   {
-                    :name   => "tag:#{config[:subnet_filter][:tag]}",
-                    :values => [config[:subnet_filter][:value]],
+                    name: "tag:#{config[:subnet_filter][:tag]}",
+                    values: [config[:subnet_filter][:value]],
                   },
                 ]
               )[0][0].subnet_id
@@ -62,12 +62,12 @@ module Kitchen
           end
 
           if config[:security_group_ids].nil? && config[:security_group_filter]
-            security_group = ::Aws::EC2::Client.
-                new(:region => config[:region]).describe_security_groups(
-                :filters => [
+            security_group = ::Aws::EC2::Client
+                .new(region: config[:region]).describe_security_groups(
+                filters: [
                     {
-                        :name => "tag:#{config[:security_group_filter][:tag]}",
-                        :values => [config[:security_group_filter][:value]],
+                        name: "tag:#{config[:security_group_filter][:tag]}",
+                        values: [config[:security_group_filter][:value]],
                     },
                 ]
             )[0][0]
@@ -81,12 +81,12 @@ module Kitchen
           end
 
           i = {
-            :instance_type                => config[:instance_type],
-            :ebs_optimized                => config[:ebs_optimized],
-            :image_id                     => config[:image_id],
-            :key_name                     => config[:aws_ssh_key_id],
-            :subnet_id                    => config[:subnet_id],
-            :private_ip_address           => config[:private_ip_address],
+            instance_type: config[:instance_type],
+            ebs_optimized: config[:ebs_optimized],
+            image_id: config[:image_id],
+            key_name: config[:aws_ssh_key_id],
+            subnet_id: config[:subnet_id],
+            private_ip_address: config[:private_ip_address],
           }
 
           availability_zone = config[:availability_zone]
@@ -94,14 +94,14 @@ module Kitchen
             if availability_zone =~ /^[a-z]$/i
               availability_zone = "#{config[:region]}#{availability_zone}"
             end
-            i[:placement] = { :availability_zone => availability_zone.downcase }
+            i[:placement] = { availability_zone: availability_zone.downcase }
           end
           tenancy = config[:tenancy]
           if tenancy
             if i.key?(:placement)
               i[:placement][:tenancy] = tenancy
             else
-              i[:placement] = { :tenancy => tenancy }
+              i[:placement] = { tenancy: tenancy }
             end
           end
           unless config[:block_device_mappings].nil? || config[:block_device_mappings].empty?
@@ -110,14 +110,14 @@ module Kitchen
           i[:security_group_ids] = Array(config[:security_group_ids]) if config[:security_group_ids]
           i[:user_data] = prepared_user_data if prepared_user_data
           if config[:iam_profile_name]
-            i[:iam_instance_profile] = { :name => config[:iam_profile_name] }
+            i[:iam_instance_profile] = { name: config[:iam_profile_name] }
           end
           if !config.fetch(:associate_public_ip, nil).nil?
             i[:network_interfaces] =
               [{
-                :device_index => 0,
-                :associate_public_ip_address => config[:associate_public_ip],
-                :delete_on_termination => true,
+                device_index: 0,
+                associate_public_ip_address: config[:associate_public_ip],
+                delete_on_termination: true,
               }]
             # If specifying `:network_interfaces` in the request, you must specify
             # network specific configs in the network_interfaces block and not at
@@ -137,14 +137,14 @@ module Kitchen
             if availability_zone =~ /^[a-z]$/i
               availability_zone = "#{config[:region]}#{availability_zone}"
             end
-            i[:placement] = { :availability_zone => availability_zone.downcase }
+            i[:placement] = { availability_zone: availability_zone.downcase }
           end
           tenancy = config[:tenancy]
           if tenancy
             if i.key?(:placement)
               i[:placement][:tenancy] = tenancy
             else
-              i[:placement] = { :tenancy => tenancy }
+              i[:placement] = { tenancy: tenancy }
             end
           end
           unless config[:instance_initiated_shutdown_behavior].nil? ||

--- a/lib/kitchen/driver/aws/standard_platform.rb
+++ b/lib/kitchen/driver/aws/standard_platform.rb
@@ -88,7 +88,7 @@ module Kitchen
         #
         # The list of supported architectures
         #
-        SUPPORTED_ARCHITECTURES = %w{x86_64 i386 arm64}
+        SUPPORTED_ARCHITECTURES = %w{x86_64 i386 arm64}.freeze
 
         #
         # Find the best matching image for the given image search.
@@ -98,11 +98,11 @@ module Kitchen
           driver.debug("Searching for images matching #{image_search} ...")
           # Convert to ec2 search format (pairs of name+values)
           filters = image_search.map do |key, value|
-            { :name => key.to_s, :values => Array(value).map(&:to_s) }
+            { name: key.to_s, values: Array(value).map(&:to_s) }
           end
 
           # We prefer most recent first
-          images = driver.ec2.resource.images(:filters => filters)
+          images = driver.ec2.resource.images(filters: filters)
           images = sort_images(images)
           show_returned_images(images)
 

--- a/lib/kitchen/driver/aws/standard_platform/centos.rb
+++ b/lib/kitchen/driver/aws/standard_platform/centos.rb
@@ -43,9 +43,9 @@ module Kitchen
             # 7.1 -> [ img1, img2, img3 ]
             # 6 -> [ img4, img5 ]
             # ...
-            images.group_by { |image| self.class.from_image(driver, image).version }.
-              sort_by { |k, _v| (k && k.include?(".") ? k.to_f : "#{k}.999".to_f) }.
-              reverse.flat_map { |_k, v| v }
+            images.group_by { |image| self.class.from_image(driver, image).version }
+              .sort_by { |k, _v| (k && k.include?(".") ? k.to_f : "#{k}.999".to_f) }
+              .reverse.flat_map { |_k, v| v }
           end
 
           def self.from_image(driver, image)

--- a/lib/kitchen/driver/aws/standard_platform/windows.rb
+++ b/lib/kitchen/driver/aws/standard_platform/windows.rb
@@ -60,9 +60,9 @@ module Kitchen
             # 2008r2rtm -> [ img1, img2, img3 ]
             # 2012r2sp1 -> [ img4, img5 ]
             # ...
-            images.group_by { |image| self.class.from_image(driver, image).windows_version_parts }.
-              sort_by { |version, _platform_images| version }.
-              reverse.flat_map { |_version, platform_images| platform_images }
+            images.group_by { |image| self.class.from_image(driver, image).windows_version_parts }
+              .sort_by { |version, _platform_images| version }
+              .reverse.flat_map { |_version, platform_images| platform_images }
           end
 
           def self.from_image(driver, image)

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -248,15 +248,15 @@ module Kitchen
         # Tagging an instance is possible before volumes are attached. Tagging the volumes after
         # instance creation is consistent.
         Retryable.retryable(
-          :tries => 10,
-          :sleep => lambda { |n| [2**n, 30].min },
-          :on => ::Aws::EC2::Errors::InvalidInstanceIDNotFound
+          tries: 10,
+          sleep: lambda { |n| [2**n, 30].min },
+          on: ::Aws::EC2::Errors::InvalidInstanceIDNotFound
         ) do |r, _|
           info("Attempting to tag the instance, #{r} retries")
           tag_server(server)
 
           # Get information about the AMI (image) used to create the image.
-          image_data = ec2.client.describe_images({ :image_ids => [server.image_id] })[0][0]
+          image_data = ec2.client.describe_images({ image_ids: [server.image_id] })[0][0]
 
           state[:server_id] = server.id
           info("EC2 instance <#{state[:server_id]}> created.")
@@ -299,7 +299,7 @@ module Kitchen
           if state[:spot_request_id]
             debug("Deleting spot request <#{state[:server_id]}>")
             ec2.client.cancel_spot_instance_requests(
-              :spot_instance_request_ids => [state[:spot_request_id]]
+              spot_instance_request_ids: [state[:spot_request_id]]
             )
             state.delete(:spot_request_id)
           end
@@ -429,7 +429,7 @@ module Kitchen
         state[:spot_request_id] = spot_request_id
         ec2.client.wait_until(
           :spot_instance_request_fulfilled,
-          :spot_instance_request_ids => [spot_request_id]
+          spot_instance_request_ids: [spot_request_id]
         ) do |w|
           w.max_attempts = config[:retryable_tries]
           w.delay = config[:retryable_sleep]
@@ -445,9 +445,9 @@ module Kitchen
       def create_spot_request
         request_duration = config[:retryable_tries] * config[:retryable_sleep]
         request_data = {
-          :spot_price => config[:spot_price].to_s,
-          :launch_specification => instance_generator.ec2_instance_data,
-          :valid_until => Time.now + request_duration,
+          spot_price: config[:spot_price].to_s,
+          launch_specification: instance_generator.ec2_instance_data,
+          valid_until: Time.now + request_duration,
         }
         if config[:block_duration_minutes]
           request_data[:block_duration_minutes] = config[:block_duration_minutes]
@@ -463,19 +463,19 @@ module Kitchen
             # we convert the value to a string because
             # nils should be passed as an empty String
             # and Integers need to be represented as Strings
-            { :key => k, :value => v.to_s }
+            { key: k, value: v.to_s }
           end
-          server.create_tags(:tags => tags)
+          server.create_tags(tags: tags)
         end
       end
 
       def tag_volumes(server)
         if config[:tags] && !config[:tags].empty?
           tags = config[:tags].map do |k, v|
-            { :key => k, :value => v.to_s }
+            { key: k, value: v.to_s }
           end
           server.volumes.each do |volume|
-            volume.create_tags(:tags => tags)
+            volume.create_tags(tags: tags)
           end
         end
       end
@@ -489,8 +489,8 @@ module Kitchen
           described_volume_count = 0
           ready_volume_count = 0
           if aws_instance.exists?
-            described_volume_count = ec2.client.describe_volumes(:filters => [
-              { :name => "attachment.instance-id", :values => ["#{state[:server_id]}"] }]
+            described_volume_count = ec2.client.describe_volumes(filters: [
+              { name: "attachment.instance-id", values: ["#{state[:server_id]}"] }]
               ).volumes.length
             aws_instance.volumes.each { ready_volume_count += 1 }
           end
@@ -538,9 +538,9 @@ module Kitchen
         begin
           with_request_limit_backoff(state) do
             server.wait_until(
-              :max_attempts => config[:retryable_tries],
-              :delay => config[:retryable_sleep],
-              :before_attempt => wait_log,
+              max_attempts: config[:retryable_tries],
+              delay: config[:retryable_sleep],
+              before_attempt: wait_log,
               &block
             )
           end
@@ -555,7 +555,7 @@ module Kitchen
       def fetch_windows_admin_password(server, state)
         wait_with_destroy(server, state, "to fetch windows admin password") do |aws_instance|
           enc = server.client.get_password_data(
-            :instance_id => state[:server_id]
+            instance_id: state[:server_id]
           ).password_data
           # Password data is blank until password is available
           !enc.nil? && !enc.empty?
@@ -591,7 +591,7 @@ module Kitchen
           "public" => "public_ip_address",
           "private" => "private_ip_address",
           "private_dns" => "private_dns_name",
-        }
+        }.freeze
 
       #
       # Lookup hostname of provided server. If interface_type is provided use
@@ -664,7 +664,7 @@ module Kitchen
         #Firewall Config
         & netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" profile=public protocol=tcp localport=5985 remoteip=localsubnet new remoteip=any  >> $logfile
         Set-ItemProperty -Name LocalAccountTokenFilterPolicy -Path HKLM:\\software\\Microsoft\\Windows\\CurrentVersion\\Policies\\system -Value 1
-	EOH
+        EOH
 
         # Preparing custom static admin user if we defined something other than Administrator
         custom_admin_script = ""
@@ -708,8 +708,8 @@ module Kitchen
       end
 
       def image_info(image)
-        root_device = image.block_device_mappings.
-          find { |b| b.device_name == image.root_device_name }
+        root_device = image.block_device_mappings
+          .find { |b| b.device_name == image.root_device_name }
         volume_type = " #{root_device.ebs.volume_type}" if root_device && root_device.ebs
 
         " Architecture: #{image.architecture}," \

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -33,13 +33,12 @@ require_relative "aws/standard_platform/fedora"
 require_relative "aws/standard_platform/freebsd"
 require_relative "aws/standard_platform/ubuntu"
 require_relative "aws/standard_platform/windows"
+require "aws-sdk-ec2"
 require "aws-sdk-core/waiters/errors"
 require "retryable"
 require "time"
 require "etc"
 require "socket"
-
-Aws.eager_autoload!
 
 module Kitchen
 
@@ -96,9 +95,6 @@ module Kitchen
 
       def initialize(*args, &block)
         super
-        # AWS Ruby SDK loading isn't thread safe, so as soon as we know we're
-        # going to use EC2, autoload it. Seems to have been fixed in Ruby 2.3+
-        ::Aws.eager_autoload! unless RUBY_VERSION.to_f >= 2.3
       end
 
       def self.validation_warn(driver, old_key, new_key)

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -22,6 +22,6 @@ module Kitchen
   module Driver
 
     # Version string for EC2 Test Kitchen driver
-    EC2_VERSION = "2.4.0"
+    EC2_VERSION = "2.4.0".freeze
   end
 end

--- a/spec/kitchen/driver/aws/image_selection_spec.rb
+++ b/spec/kitchen/driver/aws/image_selection_spec.rb
@@ -327,7 +327,7 @@ describe "Default images for various platforms" do
       { name: "name", values: %w{
         Windows_Server-2016-English-Full-Base-*} },
     ],
-  }
+  }.freeze
 
   describe "Platform defaults" do
     PLATFORM_SEARCHES.each do |platform_name, filters|
@@ -335,14 +335,14 @@ describe "Default images for various platforms" do
         let(:image) { FakeImage.new(name: platform_name.split("-", 2)[0]) }
 
         it "searches for #{filters} and uses the resulting image" do
-          expect(driver.ec2.resource).
-            to receive(:images).with(filters: filters).and_return([image])
-          expect(driver.ec2.resource).
-            to receive(:image).with(image.id).and_return(image)
+          expect(driver.ec2.resource)
+            .to receive(:images).with(filters: filters).and_return([image])
+          expect(driver.ec2.resource)
+            .to receive(:image).with(image.id).and_return(image)
 
           instance = new_instance(platform_name: platform_name)
-          expect(instance.driver.instance_generator.ec2_instance_data[:image_id]).
-            to eq image.id
+          expect(instance.driver.instance_generator.ec2_instance_data[:image_id])
+            .to eq image.id
         end
       end
     end
@@ -354,28 +354,28 @@ describe "Default images for various platforms" do
 
     context "and platform.name is a well known platform name" do
       it "searches for an image id without using the standard filters" do
-        expect(driver.ec2.resource).
-          to receive(:images).
-          with(filters: [{ name: "name", values: %w{SuperImage} }]).
-          and_return([image])
-        expect(driver.ec2.resource).
-          to receive(:image).with(image.id).and_return(image)
+        expect(driver.ec2.resource)
+          .to receive(:images)
+          .with(filters: [{ name: "name", values: %w{SuperImage} }])
+          .and_return([image])
+        expect(driver.ec2.resource)
+          .to receive(:image).with(image.id).and_return(image)
 
         instance = new_instance(platform_name: "ubuntu")
-        expect(instance.driver.instance_generator.ec2_instance_data[:image_id]).
-          to eq image.id
+        expect(instance.driver.instance_generator.ec2_instance_data[:image_id])
+          .to eq image.id
       end
     end
 
     context "and platform.name is not a well known platform name" do
       let(:image) { FakeImage.new(name: "ubuntu") }
       it "does not search for (or find) an image, and informs the user they need to set image_id" do
-        expect(driver.ec2.resource).
-          to receive(:images).
-          with(filters: [{ name: "name", values: %w{SuperImage} }]).
-          and_return([image])
-        expect(driver.ec2.resource).
-          to receive(:image).with(image.id).and_return(image)
+        expect(driver.ec2.resource)
+          .to receive(:images)
+          .with(filters: [{ name: "name", values: %w{SuperImage} }])
+          .and_return([image])
+        expect(driver.ec2.resource)
+          .to receive(:image).with(image.id).and_return(image)
 
         instance = new_instance(platform_name: "blarghle")
         expect(instance.driver.instance_generator.ec2_instance_data[:image_id]).to eq image.id

--- a/spec/kitchen/driver/aws/instance_generator_spec.rb
+++ b/spec/kitchen/driver/aws/instance_generator_spec.rb
@@ -21,7 +21,7 @@ require "kitchen/driver/aws/instance_generator"
 require "kitchen/driver/aws/client"
 require "tempfile"
 require "base64"
-require "aws-sdk"
+require "aws-sdk-ec2"
 
 describe Kitchen::Driver::Aws::InstanceGenerator do
 

--- a/spec/kitchen/driver/aws/instance_generator_spec.rb
+++ b/spec/kitchen/driver/aws/instance_generator_spec.rb
@@ -27,14 +27,14 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
 
   let(:config) { Hash.new }
   let(:resource) { instance_double(Aws::EC2::Resource) }
-  let(:ec2) { instance_double(Kitchen::Driver::Aws::Client, :resource => resource) }
+  let(:ec2) { instance_double(Kitchen::Driver::Aws::Client, resource: resource) }
   let(:logger) { instance_double(Logger) }
   let(:generator) { Kitchen::Driver::Aws::InstanceGenerator.new(config, ec2, logger) }
 
   describe "#prepared_user_data" do
     context "when config[:user_data] is a file" do
       let(:tmp_file) { Tempfile.new("prepared_user_data_test") }
-      let(:config) { { :user_data => tmp_file.path } }
+      let(:config) { { user_data: tmp_file.path } }
 
       before do
         tmp_file.write("foo\nbar")
@@ -60,7 +60,7 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     end
 
     context "when config[:user_data] is binary" do
-      let(:config) { { :user_data => "foo\0bar" } }
+      let(:config) { { user_data: "foo\0bar" } }
 
       it "handles nulls in user_data" do
         expect(Base64.decode64(generator.prepared_user_data)).to eq "foo\0bar"
@@ -69,58 +69,58 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
   end
 
   describe "#ec2_instance_data" do
-    ec2_stub = Aws::EC2::Client.new(:stub_responses => true)
+    ec2_stub = Aws::EC2::Client.new(stub_responses: true)
 
     ec2_stub.stub_responses(
       :describe_subnets,
-      :subnets => [
+      subnets: [
         {
-          :subnet_id  => "s-123",
-          :tags       => [{ :key => "foo", :value => "bar" }],
+          subnet_id: "s-123",
+          tags: [{ key: "foo", value: "bar" }],
         },
       ]
     )
 
     ec2_stub.stub_responses(
       :describe_security_groups,
-      :security_groups => [
+      security_groups: [
         {
-          :group_id => "sg-123",
-          :tags => [{ :key => "foo", :value => "bar" }],
+          group_id: "sg-123",
+          tags: [{ key: "foo", value: "bar" }],
         },
       ]
     )
 
     it "returns empty on nil" do
       expect(generator.ec2_instance_data).to eq(
-        :instance_type => nil,
-        :ebs_optimized => nil,
-        :image_id => nil,
-        :key_name => nil,
-        :subnet_id => nil,
-        :private_ip_address => nil
+        instance_type: nil,
+        ebs_optimized: nil,
+        image_id: nil,
+        key_name: nil,
+        subnet_id: nil,
+        private_ip_address: nil
       )
     end
 
     context "when populated with minimum requirements" do
       let(:config) do
         {
-          :instance_type                => "micro",
-          :ebs_optimized                => true,
-          :image_id                     => "ami-123",
-          :subnet_id                    => "s-456",
-          :private_ip_address           => "0.0.0.0",
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          subnet_id: "s-456",
+          private_ip_address: "0.0.0.0",
         }
       end
 
       it "returns the minimum data" do
         expect(generator.ec2_instance_data).to eq(
-           :instance_type => "micro",
-           :ebs_optimized => true,
-           :image_id => "ami-123",
-           :key_name => nil,
-           :subnet_id => "s-456",
-           :private_ip_address => "0.0.0.0"
+           instance_type: "micro",
+           ebs_optimized: true,
+           image_id: "ami-123",
+           key_name: nil,
+           subnet_id: "s-456",
+           private_ip_address: "0.0.0.0"
         )
       end
     end
@@ -128,23 +128,23 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when populated with ssh key" do
       let(:config) do
         {
-          :instance_type                => "micro",
-          :ebs_optimized                => true,
-          :image_id                     => "ami-123",
-          :aws_ssh_key_id               => "key",
-          :subnet_id                    => "s-456",
-          :private_ip_address           => "0.0.0.0",
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          aws_ssh_key_id: "key",
+          subnet_id: "s-456",
+          private_ip_address: "0.0.0.0",
         }
       end
 
       it "returns the minimum data" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => "micro",
-          :ebs_optimized => true,
-          :image_id => "ami-123",
-          :key_name => "key",
-          :subnet_id => "s-456",
-          :private_ip_address => "0.0.0.0"
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          key_name: "key",
+          subnet_id: "s-456",
+          private_ip_address: "0.0.0.0"
         )
       end
     end
@@ -152,16 +152,15 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when provided subnet tag instead of id" do
       let(:config) do
         {
-          :instance_type                => "micro",
-          :ebs_optimized                => true,
-          :image_id                     => "ami-123",
-          :aws_ssh_key_id               => "key",
-          :subnet_id                    => nil,
-          :region                       => "us-west-2",
-          :subnet_filter =>
-            {
-              :tag   => "foo",
-              :value => "bar",
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          aws_ssh_key_id: "key",
+          subnet_id: nil,
+          region: "us-west-2",
+          subnet_filter: {
+              tag: "foo",
+              value: "bar",
             },
         }
       end
@@ -169,10 +168,10 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       it "generates id from the provided tag" do
         allow(::Aws::EC2::Client).to receive(:new).and_return(ec2_stub)
         expect(ec2_stub).to receive(:describe_subnets).with(
-          :filters => [
+          filters: [
             {
-              :name => "tag:foo",
-              :values => ["bar"],
+              name: "tag:foo",
+              values: ["bar"],
             },
           ]
         ).and_return(ec2_stub.describe_subnets)
@@ -183,17 +182,16 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when provided security_group tag instead of id" do
       let(:config) do
         {
-          :instance_type                => "micro",
-          :ebs_optimized                => true,
-          :image_id                     => "ami-123",
-          :aws_ssh_key_id               => "key",
-          :subnet_id                    => "s-123",
-          :security_group_ids           => nil,
-          :region                       => "us-west-2",
-          :security_group_filter =>
-            {
-              :tag   => "foo",
-              :value => "bar",
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          aws_ssh_key_id: "key",
+          subnet_id: "s-123",
+          security_group_ids: nil,
+          region: "us-west-2",
+          security_group_filter: {
+              tag: "foo",
+              value: "bar",
             },
         }
       end
@@ -201,10 +199,10 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       it "generates id from the provided tag" do
         allow(::Aws::EC2::Client).to receive(:new).and_return(ec2_stub)
         expect(ec2_stub).to receive(:describe_security_groups).with(
-          :filters => [
+          filters: [
             {
-              :name => "tag:foo",
-              :values => ["bar"],
+              name: "tag:foo",
+              values: ["bar"],
             },
           ]
         ).and_return(ec2_stub.describe_security_groups)
@@ -213,21 +211,20 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     end
 
     context "when provided a non existing security_group tag filter" do
-      ec2_stub_whithout_security_group = Aws::EC2::Client.new(:stub_responses => true)
+      ec2_stub_whithout_security_group = Aws::EC2::Client.new(stub_responses: true)
 
       let(:config) do
         {
-          :instance_type                => "micro",
-          :ebs_optimized                => true,
-          :image_id                     => "ami-123",
-          :aws_ssh_key_id               => "key",
-          :subnet_id                    => "s-123",
-          :security_group_ids           => nil,
-          :region                       => "us-west-2",
-          :security_group_filter =>
-            {
-              :tag   => "foo",
-              :value => "bar",
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          aws_ssh_key_id: "key",
+          subnet_id: "s-123",
+          security_group_ids: nil,
+          region: "us-west-2",
+          security_group_filter: {
+              tag: "foo",
+              value: "bar",
             },
         }
       end
@@ -235,10 +232,10 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       it "generates id from the provided tag" do
         allow(::Aws::EC2::Client).to receive(:new).and_return(ec2_stub_whithout_security_group)
         expect(ec2_stub_whithout_security_group).to receive(:describe_security_groups).with(
-          :filters => [
+          filters: [
             {
-              :name => "tag:foo",
-              :values => ["bar"],
+              name: "tag:foo",
+              values: ["bar"],
             },
           ]
         ).and_return(ec2_stub_whithout_security_group.describe_security_groups)
@@ -251,24 +248,24 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when passed an empty block_device_mappings" do
       let(:config) do
         {
-          :instance_type                => "micro",
-          :ebs_optimized                => true,
-          :image_id                     => "ami-123",
-          :aws_ssh_key_id               => "key",
-          :subnet_id                    => "s-456",
-          :private_ip_address           => "0.0.0.0",
-          :block_device_mappings        => [],
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          aws_ssh_key_id: "key",
+          subnet_id: "s-456",
+          private_ip_address: "0.0.0.0",
+          block_device_mappings: [],
         }
       end
 
       it "does not return block_device_mappings" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => "micro",
-          :ebs_optimized => true,
-          :image_id => "ami-123",
-          :key_name => "key",
-          :subnet_id => "s-456",
-          :private_ip_address => "0.0.0.0"
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          key_name: "key",
+          subnet_id: "s-456",
+          private_ip_address: "0.0.0.0"
         )
       end
     end
@@ -276,19 +273,19 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when availability_zone is provided as 'eu-west-1c'" do
       let(:config) do
         {
-          :region => "eu-east-1",
-          :availability_zone => "eu-west-1c",
+          region: "eu-east-1",
+          availability_zone: "eu-west-1c",
         }
       end
       it "returns that in the instance data" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil,
-          :placement => { :availability_zone => "eu-west-1c" }
+          instance_type: nil,
+          ebs_optimized: nil,
+          image_id: nil,
+          key_name: nil,
+          subnet_id: nil,
+          private_ip_address: nil,
+          placement: { availability_zone: "eu-west-1c" }
         )
       end
     end
@@ -296,19 +293,19 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when availability_zone is provided as 'c'" do
       let(:config) do
         {
-          :region => "eu-east-1",
-          :availability_zone => "c",
+          region: "eu-east-1",
+          availability_zone: "c",
         }
       end
       it "adds the region to it in the instance data" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil,
-          :placement => { :availability_zone => "eu-east-1c" }
+          instance_type: nil,
+          ebs_optimized: nil,
+          image_id: nil,
+          key_name: nil,
+          subnet_id: nil,
+          private_ip_address: nil,
+          placement: { availability_zone: "eu-east-1c" }
         )
       end
     end
@@ -316,17 +313,17 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when availability_zone is not provided" do
       let(:config) do
         {
-          :region => "eu-east-1",
+          region: "eu-east-1",
         }
       end
       it "is not added to the instance data" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil
+          instance_type: nil,
+          ebs_optimized: nil,
+          image_id: nil,
+          key_name: nil,
+          subnet_id: nil,
+          private_ip_address: nil
         )
       end
     end
@@ -334,21 +331,21 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when availability_zone and tenancy are provided" do
       let(:config) do
         {
-          :region => "eu-east-1",
-          :availability_zone => "c",
-          :tenancy => "dedicated",
+          region: "eu-east-1",
+          availability_zone: "c",
+          tenancy: "dedicated",
         }
       end
       it "adds the region to it in the instance data" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil,
-          :placement => { :availability_zone => "eu-east-1c",
-                          :tenancy => "dedicated" }
+          instance_type: nil,
+          ebs_optimized: nil,
+          image_id: nil,
+          key_name: nil,
+          subnet_id: nil,
+          private_ip_address: nil,
+          placement: { availability_zone: "eu-east-1c",
+                       tenancy: "dedicated" }
         )
       end
     end
@@ -356,19 +353,19 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when tenancy is provided but availability_zone isn't" do
       let(:config) do
         {
-          :region => "eu-east-1",
-          :tenancy => "default",
+          region: "eu-east-1",
+          tenancy: "default",
         }
       end
       it "is not added to the instance data" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil,
-          :placement => { :tenancy => "default" }
+          instance_type: nil,
+          ebs_optimized: nil,
+          image_id: nil,
+          key_name: nil,
+          subnet_id: nil,
+          private_ip_address: nil,
+          placement: { tenancy: "default" }
         )
       end
     end
@@ -376,21 +373,21 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when availability_zone and tenancy are provided" do
       let(:config) do
         {
-          :region => "eu-east-1",
-          :availability_zone => "c",
-          :tenancy => "dedicated",
+          region: "eu-east-1",
+          availability_zone: "c",
+          tenancy: "dedicated",
         }
       end
       it "adds the region to it in the instance data" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil,
-          :placement => { :availability_zone => "eu-east-1c",
-                          :tenancy => "dedicated" }
+          instance_type: nil,
+          ebs_optimized: nil,
+          image_id: nil,
+          key_name: nil,
+          subnet_id: nil,
+          private_ip_address: nil,
+          placement: { availability_zone: "eu-east-1c",
+                       tenancy: "dedicated" }
         )
       end
     end
@@ -398,19 +395,19 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when tenancy is provided but availability_zone isn't" do
       let(:config) do
         {
-          :region => "eu-east-1",
-          :tenancy => "default",
+          region: "eu-east-1",
+          tenancy: "default",
         }
       end
       it "is not added to the instance data" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil,
-          :placement => { :tenancy => "default" }
+          instance_type: nil,
+          ebs_optimized: nil,
+          image_id: nil,
+          key_name: nil,
+          subnet_id: nil,
+          private_ip_address: nil,
+          placement: { tenancy: "default" }
         )
       end
     end
@@ -418,18 +415,18 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when subnet_id is provided" do
       let(:config) do
         {
-          :subnet_id => "s-456",
+          subnet_id: "s-456",
         }
       end
 
       it "adds a network_interfaces block" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => "s-456",
-          :private_ip_address => nil
+          instance_type: nil,
+          ebs_optimized: nil,
+          image_id: nil,
+          key_name: nil,
+          subnet_id: "s-456",
+          private_ip_address: nil
         )
       end
     end
@@ -437,22 +434,22 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when associate_public_ip is provided" do
       let(:config) do
         {
-          :associate_public_ip => true,
+          associate_public_ip: true,
         }
       end
 
       it "adds a network_interfaces block" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => nil,
-          :ebs_optimized => nil,
-          :image_id => nil,
-          :key_name => nil,
-          :subnet_id => nil,
-          :private_ip_address => nil,
-          :network_interfaces => [{
-            :device_index => 0,
-            :associate_public_ip_address => true,
-            :delete_on_termination => true,
+          instance_type: nil,
+          ebs_optimized: nil,
+          image_id: nil,
+          key_name: nil,
+          subnet_id: nil,
+          private_ip_address: nil,
+          network_interfaces: [{
+            device_index: 0,
+            associate_public_ip_address: true,
+            delete_on_termination: true,
           }]
         )
       end
@@ -460,23 +457,23 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       context "and subnet is provided" do
         let(:config) do
           {
-            :associate_public_ip => true,
-            :subnet_id => "s-456",
+            associate_public_ip: true,
+            subnet_id: "s-456",
           }
         end
 
         it "adds a network_interfaces block" do
           expect(generator.ec2_instance_data).to eq(
-            :instance_type => nil,
-            :ebs_optimized => nil,
-            :image_id => nil,
-            :key_name => nil,
-            :private_ip_address => nil,
-            :network_interfaces => [{
-              :device_index => 0,
-              :associate_public_ip_address => true,
-              :delete_on_termination => true,
-              :subnet_id => "s-456",
+            instance_type: nil,
+            ebs_optimized: nil,
+            image_id: nil,
+            key_name: nil,
+            private_ip_address: nil,
+            network_interfaces: [{
+              device_index: 0,
+              associate_public_ip_address: true,
+              delete_on_termination: true,
+              subnet_id: "s-456",
             }]
           )
         end
@@ -485,24 +482,24 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       context "and security_group_ids is provided" do
         let(:config) do
           {
-            :associate_public_ip => true,
-            :security_group_ids => ["sg-789"],
+            associate_public_ip: true,
+            security_group_ids: ["sg-789"],
           }
         end
 
         it "adds a network_interfaces block" do
           expect(generator.ec2_instance_data).to eq(
-            :instance_type => nil,
-            :ebs_optimized => nil,
-            :image_id => nil,
-            :key_name => nil,
-            :subnet_id => nil,
-            :private_ip_address => nil,
-            :network_interfaces => [{
-              :device_index => 0,
-              :associate_public_ip_address => true,
-              :delete_on_termination => true,
-              :groups => ["sg-789"],
+            instance_type: nil,
+            ebs_optimized: nil,
+            image_id: nil,
+            key_name: nil,
+            subnet_id: nil,
+            private_ip_address: nil,
+            network_interfaces: [{
+              device_index: 0,
+              associate_public_ip_address: true,
+              delete_on_termination: true,
+              groups: ["sg-789"],
             }]
           )
         end
@@ -511,11 +508,11 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           config[:security_group_ids] = "only-one"
 
           expect(generator.ec2_instance_data).to include(
-            :network_interfaces => [{
-              :device_index => 0,
-              :associate_public_ip_address => true,
-              :delete_on_termination => true,
-              :groups => ["only-one"],
+            network_interfaces: [{
+              device_index: 0,
+              associate_public_ip_address: true,
+              delete_on_termination: true,
+              groups: ["only-one"],
             }]
           )
         end
@@ -524,23 +521,23 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
       context "and private_ip_address is provided" do
         let(:config) do
           {
-            :associate_public_ip => true,
-            :private_ip_address => "0.0.0.0",
+            associate_public_ip: true,
+            private_ip_address: "0.0.0.0",
           }
         end
 
         it "adds a network_interfaces block" do
           expect(generator.ec2_instance_data).to eq(
-            :instance_type => nil,
-            :ebs_optimized => nil,
-            :image_id => nil,
-            :key_name => nil,
-            :subnet_id => nil,
-            :network_interfaces => [{
-              :device_index => 0,
-              :associate_public_ip_address => true,
-              :delete_on_termination => true,
-              :private_ip_address => "0.0.0.0",
+            instance_type: nil,
+            ebs_optimized: nil,
+            image_id: nil,
+            key_name: nil,
+            subnet_id: nil,
+            network_interfaces: [{
+              device_index: 0,
+              associate_public_ip_address: true,
+              delete_on_termination: true,
+              private_ip_address: "0.0.0.0",
             }]
           )
         end
@@ -550,61 +547,61 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
     context "when provided the maximum config" do
       let(:config) do
         {
-          :availability_zone            => "eu-west-1a",
-          :instance_type                => "micro",
-          :ebs_optimized                => true,
-          :image_id                     => "ami-123",
-          :aws_ssh_key_id               => "key",
-          :subnet_id                    => "s-456",
-          :private_ip_address           => "0.0.0.0",
-          :block_device_mappings => [
+          availability_zone: "eu-west-1a",
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          aws_ssh_key_id: "key",
+          subnet_id: "s-456",
+          private_ip_address: "0.0.0.0",
+          block_device_mappings: [
             {
-              :device_name => "/dev/sda2",
-              :virtual_name => "test",
-              :ebs => {
-                :volume_size => 15,
-                :delete_on_termination => false,
-                :volume_type => "gp2",
-                :snapshot_id => "id",
+              device_name: "/dev/sda2",
+              virtual_name: "test",
+              ebs: {
+                volume_size: 15,
+                delete_on_termination: false,
+                volume_type: "gp2",
+                snapshot_id: "id",
               },
             },
           ],
-          :security_group_ids => ["sg-789"],
-          :user_data => "foo",
-          :iam_profile_name => "iam-123",
-          :associate_public_ip => true,
+          security_group_ids: ["sg-789"],
+          user_data: "foo",
+          iam_profile_name: "iam-123",
+          associate_public_ip: true,
         }
       end
 
       it "returns the maximum data" do
         expect(generator.ec2_instance_data).to eq(
-          :instance_type => "micro",
-          :ebs_optimized => true,
-          :image_id => "ami-123",
-          :key_name => "key",
-          :block_device_mappings => [
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          key_name: "key",
+          block_device_mappings: [
             {
-              :device_name => "/dev/sda2",
-              :virtual_name => "test",
-              :ebs => {
-                :volume_size => 15,
-                :delete_on_termination => false,
-                :volume_type => "gp2",
-                :snapshot_id => "id",
+              device_name: "/dev/sda2",
+              virtual_name: "test",
+              ebs: {
+                volume_size: 15,
+                delete_on_termination: false,
+                volume_type: "gp2",
+                snapshot_id: "id",
               },
             },
           ],
-          :iam_instance_profile => { :name => "iam-123" },
-          :network_interfaces => [{
-            :device_index => 0,
-            :associate_public_ip_address => true,
-            :subnet_id => "s-456",
-            :delete_on_termination => true,
-            :groups => ["sg-789"],
-            :private_ip_address =>  "0.0.0.0",
+          iam_instance_profile: { name: "iam-123" },
+          network_interfaces: [{
+            device_index: 0,
+            associate_public_ip_address: true,
+            subnet_id: "s-456",
+            delete_on_termination: true,
+            groups: ["sg-789"],
+            private_ip_address: "0.0.0.0",
           }],
-          :placement => { :availability_zone => "eu-west-1a" },
-          :user_data => Base64.encode64("foo")
+          placement: { availability_zone: "eu-west-1a" },
+          user_data: Base64.encode64("foo")
         )
       end
     end

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -28,21 +28,21 @@ describe Kitchen::Driver::Ec2 do
   let(:logger)        { Logger.new(logged_output) }
   let(:config) do
     {
-      :aws_ssh_key_id => "key",
-      :image_id => "ami-1234567",
-      :block_duration_minutes => 60,
-      :subnet_id => "subnet-1234",
-      :security_group_ids => ["sg-56789"],
+      aws_ssh_key_id: "key",
+      image_id: "ami-1234567",
+      block_duration_minutes: 60,
+      subnet_id: "subnet-1234",
+      security_group_ids: ["sg-56789"],
     }
   end
-  let(:platform)      { Kitchen::Platform.new(:name => "fooos-99") }
+  let(:platform)      { Kitchen::Platform.new(name: "fooos-99") }
   let(:transport)     { Kitchen::Transport::Dummy.new }
   let(:provisioner)   { Kitchen::Provisioner::Dummy.new }
   let(:generator)     { instance_double(Kitchen::Driver::Aws::InstanceGenerator) }
   # There is too much name overlap I let creep in - my `client` is actually
   # a wrapper around the actual ec2 client
   let(:actual_client) { double("actual ec2 client") }
-  let(:client)        { double(Kitchen::Driver::Aws::Client, :client => actual_client) }
+  let(:client)        { double(Kitchen::Driver::Aws::Client, client: actual_client) }
   let(:server) { double("aws server object") }
   let(:state) { {} }
 
@@ -51,11 +51,11 @@ describe Kitchen::Driver::Ec2 do
   let(:instance) do
     instance_double(
       Kitchen::Instance,
-      :logger => logger,
-      :transport => transport,
-      :provisioner => provisioner,
-      :platform => platform,
-      :to_str => "str"
+      logger: logger,
+      transport: transport,
+      provisioner: provisioner,
+      platform: platform,
+      to_str: "str"
     )
   end
 
@@ -77,7 +77,7 @@ describe Kitchen::Driver::Ec2 do
 
   describe "default_config" do
     context "Windows" do
-      let(:resource) { instance_double(::Aws::EC2::Resource, :image => image) }
+      let(:resource) { instance_double(::Aws::EC2::Resource, image: image) }
       before do
         allow(driver).to receive(:windows_os?).and_return(true)
         allow(client).to receive(:resource).and_return(resource)
@@ -85,7 +85,7 @@ describe Kitchen::Driver::Ec2 do
       end
       context "Windows 2016" do
         let(:image) do
-          FakeImage.new(:name => "Windows_Server-2016-English-Full-Base-2017.01.11")
+          FakeImage.new(name: "Windows_Server-2016-English-Full-Base-2017.01.11")
         end
         it "sets :user_data to something" do
           expect(driver[:user_data]).to include
@@ -94,7 +94,7 @@ describe Kitchen::Driver::Ec2 do
       end
       context "Windows 2012R2" do
         let(:image) do
-          FakeImage.new(:name => "Windows_Server-2012-R2_RTM-English-64Bit-Base-2017.01.11")
+          FakeImage.new(name: "Windows_Server-2012-R2_RTM-English-64Bit-Base-2017.01.11")
         end
         it "sets :user_data to something" do
           expect(driver[:user_data]).to include
@@ -111,10 +111,10 @@ describe Kitchen::Driver::Ec2 do
     let(:private_ip_address) { nil }
     let(:server) do
       double("server",
-        :public_dns_name => public_dns_name,
-        :private_dns_name => private_dns_name,
-        :public_ip_address => public_ip_address,
-        :private_ip_address => private_ip_address
+        public_dns_name: public_dns_name,
+        private_dns_name: private_dns_name,
+        public_ip_address: public_ip_address,
+        private_ip_address: private_ip_address
       )
     end
 
@@ -216,7 +216,7 @@ describe Kitchen::Driver::Ec2 do
 
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
-      expect(client).to receive(:create_instance).with(:min_count => 1, :max_count => 1)
+      expect(client).to receive(:create_instance).with(min_count: 1, max_count: 1)
       driver.submit_server
     end
   end
@@ -229,10 +229,10 @@ describe Kitchen::Driver::Ec2 do
 
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return(
-        :instance_initiated_shutdown_behavior => "terminate"
+        instance_initiated_shutdown_behavior: "terminate"
       )
       expect(client).to receive(:create_instance).with(
-        :min_count => 1, :max_count => 1, :instance_initiated_shutdown_behavior => "terminate"
+        min_count: 1, max_count: 1, instance_initiated_shutdown_behavior: "terminate"
       )
       driver.submit_server
     end
@@ -241,7 +241,7 @@ describe Kitchen::Driver::Ec2 do
   describe "#submit_spot" do
     let(:state) { {} }
     let(:response) do
-      { :spot_instance_requests => [{ :spot_instance_request_id => "id" }] }
+      { spot_instance_requests: [{ spot_instance_request_id: "id" }] }
     end
 
     before do
@@ -252,15 +252,15 @@ describe Kitchen::Driver::Ec2 do
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
       expect(actual_client).to receive(:request_spot_instances).with(
-        :spot_price => "",
-        :launch_specification => {},
-        :valid_until => Time.now + (config[:retryable_tries] * config[:retryable_sleep]),
-        :block_duration_minutes => 60
+        spot_price: "",
+        launch_specification: {},
+        valid_until: Time.now + (config[:retryable_tries] * config[:retryable_sleep]),
+        block_duration_minutes: 60
       ).and_return(response)
       expect(actual_client).to receive(:wait_until)
       expect(client).to receive(:get_instance_from_spot_request).with("id")
       driver.submit_spot(state)
-      expect(state).to eq(:spot_request_id => "id")
+      expect(state).to eq(spot_request_id: "id")
     end
   end
 
@@ -274,11 +274,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with standard string tags" do
       it "tags the server" do
-        config[:tags] = { :key1 => "value1", :key2 => "value2" }
+        config[:tags] = { key1: "value1", key2: "value2" }
         expect(server).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "value2" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "value2" },
           ]
         )
         driver.tag_server(server)
@@ -287,11 +287,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with a tag that includes a Integer value" do
       it "tags the server" do
-        config[:tags] = { :key1 => "value1", :key2 => 1 }
+        config[:tags] = { key1: "value1", key2: 1 }
         expect(server).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "1" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "1" },
           ]
         )
         driver.tag_server(server)
@@ -300,11 +300,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with a tag that includes a Nil value" do
       it "tags the server" do
-        config[:tags] = { :key1 => "value1", :key2 => nil }
+        config[:tags] = { key1: "value1", key2: nil }
         expect(server).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "" },
           ]
         )
         driver.tag_server(server)
@@ -319,11 +319,11 @@ describe Kitchen::Driver::Ec2 do
     end
     context "with standard string tags" do
       it "tags the instance volumes" do
-        config[:tags] = { :key1 => "value1", :key2 => "value2" }
+        config[:tags] = { key1: "value1", key2: "value2" }
         expect(volume).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "value2" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "value2" },
           ]
         )
         driver.tag_volumes(server)
@@ -332,11 +332,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with a tag that includes a Integer value" do
       it "tags the instance volumes" do
-        config[:tags] = { :key1 => "value1", :key2 => 2 }
+        config[:tags] = { key1: "value1", key2: 2 }
         expect(volume).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "2" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "2" },
           ]
         )
         driver.tag_volumes(server)
@@ -345,11 +345,11 @@ describe Kitchen::Driver::Ec2 do
 
     context "with a tag that includes a Nil value" do
       it "tags the instance volumes" do
-        config[:tags] = { :key1 => "value1", :key2 => nil }
+        config[:tags] = { key1: "value1", key2: nil }
         expect(volume).to receive(:create_tags).with(
-          :tags => [
-            { :key => :key1, :value => "value1" },
-            { :key => :key2, :value => "" },
+          tags: [
+            { key: :key1, value: "value1" },
+            { key: :key2, value: "" },
           ]
         )
         driver.tag_volumes(server)
@@ -442,9 +442,9 @@ describe Kitchen::Driver::Ec2 do
     let(:aws_instance) { double("aws instance") }
     let(:server_id) { "server_id" }
     let(:encrypted_password) { "alksdofw" }
-    let(:data) { double("data", :password_data => encrypted_password) }
+    let(:data) { double("data", password_data: encrypted_password) }
     let(:password) { "password" }
-    let(:transport) { { :ssh_key => "foo" } }
+    let(:transport) { { ssh_key: "foo" } }
 
     before do
       state[:server_id] = server_id
@@ -457,11 +457,11 @@ describe Kitchen::Driver::Ec2 do
 
     it "fetches and decrypts the windows password" do
       expect(server).to receive_message_chain("client.get_password_data").with(
-        :instance_id => server_id
+        instance_id: server_id
       ).and_return(data)
-      expect(server).to receive(:decrypt_windows_password).
-        with(File.expand_path("foo")).
-        and_return(password)
+      expect(server).to receive(:decrypt_windows_password)
+        .with(File.expand_path("foo"))
+        .and_return(password)
       driver.fetch_windows_admin_password(server, state)
     end
 
@@ -522,7 +522,7 @@ describe Kitchen::Driver::Ec2 do
   end
 
   describe "#create" do
-    let(:server) { double("aws server object", :id => id, :image_id => "ami-3f807145") }
+    let(:server) { double("aws server object", id: id, image_id: "ami-3f807145") }
     let(:id) { "i-12345" }
 
     it "returns if the instance is already created" do
@@ -530,7 +530,7 @@ describe Kitchen::Driver::Ec2 do
       expect(driver.create(state)).to eq(nil)
     end
 
-    image_data = Aws::EC2::Types::Image.new(:root_device_type => "ebs")
+    image_data = Aws::EC2::Types::Image.new(root_device_type: "ebs")
     ec2_stub = Aws::EC2::Types::DescribeImagesResult.new
     ec2_stub.images = [image_data]
 
@@ -542,7 +542,7 @@ describe Kitchen::Driver::Ec2 do
         expect(driver).to receive(:tag_volumes).with(server)
         expect(driver).to receive(:wait_until_volumes_ready).with(server, state)
         expect(driver).to receive(:wait_until_ready).with(server, state)
-        allow(actual_client).to receive(:describe_images).with({ :image_ids => [server.image_id] }).and_return(ec2_stub)
+        allow(actual_client).to receive(:describe_images).with({ image_ids: [server.image_id] }).and_return(ec2_stub)
         expect(transport).to receive_message_chain("connection.wait_until_ready")
         driver.create(state)
         expect(state[:server_id]).to eq(id)
@@ -550,7 +550,7 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context "chef provisioner" do
-      let(:provisioner) { double("chef provisioner", :name => "chef_solo") }
+      let(:provisioner) { double("chef provisioner", name: "chef_solo") }
 
       before do
         expect(driver).to receive(:create_ec2_json).with(state)
@@ -755,7 +755,7 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context "when state has a normal server_id" do
-      let(:state) { { :server_id => "id", :hostname => "name" } }
+      let(:state) { { server_id: "id", hostname: "name" } }
 
       context "the server is already destroyed" do
         it "does nothing" do
@@ -775,14 +775,14 @@ describe Kitchen::Driver::Ec2 do
     end
 
     context "when state has a spot request" do
-      let(:state) { { :server_id => "id", :hostname => "name", :spot_request_id => "spot" } }
+      let(:state) { { server_id: "id", hostname: "name", spot_request_id: "spot" } }
 
       it "destroys the server" do
         expect(client).to receive(:get_instance).with("id").and_return(server)
         expect(instance).to receive_message_chain("transport.connection.close")
         expect(server).to receive(:terminate)
         expect(actual_client).to receive(:cancel_spot_instance_requests).with(
-          :spot_instance_request_ids => ["spot"]
+          spot_instance_request_ids: ["spot"]
         )
         driver.destroy(state)
         expect(state).to eq({})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,6 +102,6 @@ RSpec.configure do |config|
 
 end
 
-require "aws-sdk"
+require "aws-sdk-ec2"
 # https://ruby.awsblog.com/post/Tx15V81MLPR8D73/Client-Response-Stubs
 Aws.config[:stub_responses] = true


### PR DESCRIPTION
Stop depending on the monolithic AWS sdk when we only need the ec2 SDK, which is tiny in comparison.

This is basically https://github.com/test-kitchen/kitchen-ec2/pull/339, but only with the aws / ruby change and w/o the various chefstyle updates.

Signed-off-by: Tim Smith <tsmith@chef.io>