### PR TITLE
Fallback to ordered mapping when failed to detect hostname using interface_type

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -513,6 +513,10 @@ module Kitchen
             aws_instance.state.name == "running" &&
             hostname != "0.0.0.0"
           if ready && windows_os?
+            if hostname.nil? || hostname == ""
+              debug("Unable to detect hostname using interface_type #{config[:interface]}. Fallback to ordered mapping")
+              state[:hostname] = hostname(aws_instance, nil)
+            end
             output = server.console_output.output
             unless output.nil?
               output = Base64.decode64(output)

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -512,11 +512,12 @@ module Kitchen
           ready = aws_instance.exists? &&
             aws_instance.state.name == "running" &&
             hostname != "0.0.0.0"
+
+          if ready && ( hostname.nil? || hostname == "" )
+            debug("Unable to detect hostname using interface_type #{config[:interface]}. Fallback to ordered mapping")
+            state[:hostname] = hostname(aws_instance, nil)
+          end
           if ready && windows_os?
-            if hostname.nil? || hostname == ""
-              debug("Unable to detect hostname using interface_type #{config[:interface]}. Fallback to ordered mapping")
-              state[:hostname] = hostname(aws_instance, nil)
-            end
             output = server.console_output.output
             unless output.nil?
               output = Base64.decode64(output)


### PR DESCRIPTION
Fixes #420 

When public ip address is not enabled, then kitchen-ec2 is unable to detect hostname of a created vm.