### PR TITLE
Remove github_changelog_generator & don't include specs in the gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,3 @@ group :test do
   gem "rake"
   gem "pry"
 end
-
-group :changelog do
-  gem "github_changelog_generator"
-end

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -6,15 +6,14 @@ require "kitchen/driver/ec2_version.rb"
 Gem::Specification.new do |gem|
   gem.name          = "kitchen-ec2"
   gem.version       = Kitchen::Driver::EC2_VERSION
-  gem.license       = "Apache 2.0"
+  gem.license       = "Apache-2.0"
   gem.authors       = ["Fletcher Nichol"]
   gem.email         = ["fnichol@nichol.ca"]
   gem.description   = "A Test Kitchen Driver for Amazon EC2"
   gem.summary       = gem.description
   gem.homepage      = "https://kitchen.ci/"
 
-  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  gem.executables   = []
+  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^CHANGELOG|^lib/)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
Slim down our deps and install size a bit

Signed-off-by: Tim Smith <tsmith@chef.io>