### PR TITLE
fix architecture comparison during image sorting

### DIFF
--- a/lib/kitchen/driver/aws/standard_platform.rb
+++ b/lib/kitchen/driver/aws/standard_platform.rb
@@ -209,7 +209,7 @@ module Kitchen
           # P6: We prefer more recent images over older ones
           images = images.sort_by(&:creation_date).reverse
           # P5: We prefer x86_64 over i386 (if available)
-          images = prefer(images) { |image| image.architecture == :x86_64 }
+          images = prefer(images) { |image| image.architecture == "x86_64" }
           # P4: We prefer gp2 (SSD) (if available)
           images = prefer(images) do |image|
             image.block_device_mappings.any? do |b|


### PR DESCRIPTION
`image.architecture` returns a String, so comparing it to a symbol will always be false.

This should fix #431 for default TK+EC2 configurations returning `x86_64` architectures to the top of the preferred list of images.

Before:
```
kitchen-ec2 > 🌴 master> be pry

[1] pry(main)> require "kitchen/driver/ec2"
=> true
[2] pry(main)> require "kitchen/provisioner/dummy"
=> true
[3] pry(main)> require "kitchen/transport/dummy"
=> true
[4] pry(main)> require "kitchen/verifier/dummy"
=> true

[5] pry(main)> instance = Kitchen::Instance.new(
[5] pry(main)*   driver: Kitchen::Driver::Ec2.new(region: "us-east-1", aws_ssh_key_id: "foo"),
[5] pry(main)*   lifecycle_hooks: Kitchen::LifecycleHooks.new({}),
[5] pry(main)*   suite: Kitchen::Suite.new(name: "suite-name"),
[5] pry(main)*   platform: Kitchen::Platform.new(name: "playname"),
[5] pry(main)*   provisioner: Kitchen::Provisioner::Dummy.new,
[5] pry(main)*   transport: Kitchen::Transport::Dummy.new,
[5] pry(main)*   verifier: Kitchen::Verifier::Dummy.new,
[5] pry(main)*   state_file: Kitchen::StateFile.new("/nonexistent", "suite-name-playname")
[5] pry(main)* )
=> #<Kitchen::Instance:0x00007fe9a9c47378>

[6] pry(main)> instance.driver.image.architecture
       instance_type not specified. Using free tier t2.micro instance ...
       Detected platform: ubuntu version 18.10 on arm64. Instance Type: t2.micro. Default username: ubuntu (default).
=> "arm64"
```

After:
```
[8] pry(main)> instance.driver.image.architecture
       instance_type not specified. Using free tier t2.micro instance ...
       Detected platform: ubuntu version 18.10 on x86_64. Instance Type: t2.micro. Default username: ubuntu (default).
=> "x86_64"
```