### PR TITLE
Don't ship the changelog in the gem artifact

### DIFF
--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |gem|
   gem.email         = ["fnichol@nichol.ca"]
   gem.description   = "A Test Kitchen Driver for Amazon EC2"
   gem.summary       = gem.description
-  gem.homepage      = "https://kitchen.ci/"
+  gem.homepage      = "https://github.com/test-kitchen/kitchen-ec2"
 
-  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^CHANGELOG|^lib/)
+  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^lib/)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
There's no need for a changelog in a runtime artifact

Signed-off-by: Tim Smith <tsmith@chef.io>