### PR TITLE
Allow asking for multiple instance types and subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ region.
 The EC2 [instance type][instance_docs] (also known as size) to use.
 
 The default is `t2.micro` or `t1.micro`, depending on whether the image is `hvm`
-or `paravirtual`. (`paravirtual` images are incompatible with `t2.micro`.)
+or `paravirtual`. (`paravirtual` images are incompatible with `t2.micro`). When working with spots, you can provide an array of instance types in which case the driver will try each type until it can get a spot.
 
 #### `security_group_ids`
 
@@ -238,6 +238,7 @@ Otherwise the default is `"us-east-1"`.
 #### `subnet_id`
 
 The EC2 [subnet][subnet_docs] to use.
+When working with spots, you can provide an array in which case the driver will try each subnet until it can get a spot.
 
 The default is unset, or `nil`.
 
@@ -304,7 +305,7 @@ See [AWS documentation](https://aws.amazon.com/de/blogs/security/granting-permis
 
 #### `spot_price`
 
-The price you bid in order to submit a spot request. An additional step will be required during the spot request process submission. If no price is set, it will use an on-demand instance.
+The price you bid in order to submit a spot request. An additional step will be required during the spot request process submission. If no price is set, it will use an on-demand instance. It accepts `on-demand` string in which case the price is the current on-demand price.
 
 The default is `nil`.
 

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -254,7 +254,7 @@ describe Kitchen::Driver::Ec2 do
       expect(actual_client).to receive(:request_spot_instances).with(
         spot_price: "",
         launch_specification: {},
-        valid_until: Time.now + (config[:retryable_tries] * config[:retryable_sleep]),
+        valid_until: Time.now + config[:spot_wait],
         block_duration_minutes: 60
       ).and_return(response)
       expect(actual_client).to receive(:wait_until)
@@ -581,10 +581,41 @@ describe Kitchen::Driver::Ec2 do
     context "config is for a spot instance" do
       before do
         config[:spot_price] = 1
-        expect(driver).to receive(:submit_spot).with(state).and_return(server)
       end
 
-      include_examples "common create"
+      context "price is numeric" do
+        before do
+          expect(driver).to receive(:submit_spots).with(state).and_return(server)
+        end
+
+        include_examples "common create"
+      end
+
+      context "price is on-demand" do
+        before do
+          config[:spot_price] = "on-demand"
+          expect(driver).to receive(:submit_spots).with(state).and_return(server)
+        end
+
+        include_examples "common create"
+      end
+
+      context "instance_type is an array" do
+        before do
+          config[:instance_type] = %w{t1 t2}
+          expect(driver).to receive(:submit_spot).with(state).and_return(server)
+        end
+
+        include_examples "common create"
+
+        context "subnets is also an array" do
+          before do
+            config[:subnet_id] = %w{t1 t2}
+          end
+
+          include_examples "common create"
+        end
+      end
     end
 
     context "instance is not ebs-backed" do


### PR DESCRIPTION
This is a solution for https://github.com/test-kitchen/kitchen-ec2/issues/417.
`instance_type` and `subnet` can be arrays.
`spot_price` can be 'on-demand'.

It allows trying harder getting a spot before failing.