### PR TITLE
Warn but properly lookup full debian versions like 9.6

### DIFF
--- a/lib/kitchen/driver/aws/standard_platform/debian.rb
+++ b/lib/kitchen/driver/aws/standard_platform/debian.rb
@@ -26,20 +26,25 @@ module Kitchen
           # 10/11 are listed last since we default to the first item in the hash
           # and 10/11 are not released yet. When they're released move them up
           DEBIAN_CODENAMES = {
-            "9" => "stretch",
-            "8" => "jessie",
-            "7" => "wheezy",
-            "6" => "squeeze",
-            "11" => "bullseye",
-            "10" => "buster",
-          }
+            9 => "stretch",
+            8 => "jessie",
+            7 => "wheezy",
+            6 => "squeeze",
+            11 => "bullseye",
+            10 => "buster",
+          }.freeze
 
           def username
             "admin"
           end
 
           def codename
-            version ? DEBIAN_CODENAMES[version] : DEBIAN_CODENAMES.values.first
+            v = version
+            if v && v.size > 1
+              warn("WARN: Debian version #{version} specified, but searching for #{version.to_i} instead.")
+              v = v.to_i
+            end
+            v ? DEBIAN_CODENAMES[v.to_i] : DEBIAN_CODENAMES.values.first
           end
 
           def image_search

--- a/spec/kitchen/driver/aws/image_selection_spec.rb
+++ b/spec/kitchen/driver/aws/image_selection_spec.rb
@@ -118,6 +118,10 @@ describe "Default images for various platforms" do
       { name: "owner-id", values: %w{379101102735} },
       { name: "name", values: %w{debian-stretch-*} },
     ],
+    "debian-9.6" => [
+      { name: "owner-id", values: %w{379101102735} },
+      { name: "name", values: %w{debian-stretch-*} },
+    ],
     "debian-8" => [
       { name: "owner-id", values: %w{379101102735} },
       { name: "name", values: %w{debian-jessie-*} },


### PR DESCRIPTION
If a user passes a full version like 9.6 we should warn and then lookup 9 instead instead of just failing with a bogus error.

Signed-off-by: Tim Smith <tsmith@chef.io>