### PR TITLE
Ensure tags keys are strings as expected by AWS SDK

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -463,7 +463,7 @@ module Kitchen
             # we convert the value to a string because
             # nils should be passed as an empty String
             # and Integers need to be represented as Strings
-            { key: k, value: v.to_s }
+            { key: k.to_s, value: v.to_s }
           end
           server.create_tags(tags: tags)
         end
@@ -472,7 +472,7 @@ module Kitchen
       def tag_volumes(server)
         if config[:tags] && !config[:tags].empty?
           tags = config[:tags].map do |k, v|
-            { key: k, value: v.to_s }
+            { key: k.to_s, value: v.to_s }
           end
           server.volumes.each do |volume|
             volume.create_tags(tags: tags)

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -277,8 +277,18 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { key1: "value1", key2: "value2" }
         expect(server).to receive(:create_tags).with(
           tags: [
-            { key: :key1, value: "value1" },
-            { key: :key2, value: "value2" },
+            { key: "key1", value: "value1" },
+            { key: "key2", value: "value2" },
+          ]
+        )
+        driver.tag_server(server)
+      end
+      it "tags the server with String keys" do
+        config[:tags] = { key1: "value1", "key2" => "value2" }
+        expect(server).to receive(:create_tags).with(
+          tags: [
+            { key: "key1", value: "value1" },
+            { key: "key2", value: "value2" },
           ]
         )
         driver.tag_server(server)
@@ -290,8 +300,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { key1: "value1", key2: 1 }
         expect(server).to receive(:create_tags).with(
           tags: [
-            { key: :key1, value: "value1" },
-            { key: :key2, value: "1" },
+            { key: "key1", value: "value1" },
+            { key: "key2", value: "1" },
           ]
         )
         driver.tag_server(server)
@@ -303,8 +313,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { key1: "value1", key2: nil }
         expect(server).to receive(:create_tags).with(
           tags: [
-            { key: :key1, value: "value1" },
-            { key: :key2, value: "" },
+            { key: "key1", value: "value1" },
+            { key: "key2", value: "" },
           ]
         )
         driver.tag_server(server)
@@ -322,8 +332,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { key1: "value1", key2: "value2" }
         expect(volume).to receive(:create_tags).with(
           tags: [
-            { key: :key1, value: "value1" },
-            { key: :key2, value: "value2" },
+            { key: "key1", value: "value1" },
+            { key: "key2", value: "value2" },
           ]
         )
         driver.tag_volumes(server)
@@ -335,8 +345,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { key1: "value1", key2: 2 }
         expect(volume).to receive(:create_tags).with(
           tags: [
-            { key: :key1, value: "value1" },
-            { key: :key2, value: "2" },
+            { key: "key1", value: "value1" },
+            { key: "key2", value: "2" },
           ]
         )
         driver.tag_volumes(server)
@@ -348,8 +358,8 @@ describe Kitchen::Driver::Ec2 do
         config[:tags] = { key1: "value1", key2: nil }
         expect(volume).to receive(:create_tags).with(
           tags: [
-            { key: :key1, value: "value1" },
-            { key: :key2, value: "" },
+            { key: "key1", value: "value1" },
+            { key: "key2", value: "" },
           ]
         )
         driver.tag_volumes(server)


### PR DESCRIPTION
This commit transform all tags key to Strings, because the ec2 SDK requires it.
See https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-ec2/lib/aws-sdk-ec2/tag.rb#L260

This is a reproduction of #111 which I think reoccured when we switch from aws-sdk to aws-sdk-ec2 in 434dc6c97d4a3c4d97ff1f1515a323dc8bc4636.

Tests have been updated and a new "dummy" one has been added for non-regression.
