### PR TITLE
Fix aws-sdk-ec2 deprecation warnings

### DIFF
--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -50,7 +50,7 @@ module Kitchen
         end
 
         def create_instance(options)
-          resource.create_instances(options)[0]
+          resource.create_instances(options).first
         end
 
         def get_instance(id)

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -236,11 +236,8 @@ module Kitchen
         end
         info("Instance <#{server.id}> requested.")
         with_request_limit_backoff(state) do
-          server.wait_until_exists do |w|
-            w.before_attempt do |attempts|
-              info("Polling AWS for existence, attempt #{attempts}...")
-            end
-          end
+          logging_proc = ->(attempts) { info("Polling AWS for existence, attempt #{attempts}...") }
+          server.wait_until_exists(before_attempt: logging_proc)
         end
 
         # See https://github.com/aws/aws-sdk-ruby/issues/859


### PR DESCRIPTION
The `[]` operator on Instance::Collection is deprecated.
Yielding the instance waiter to a block is deprecated.