### PR TITLE
Avoid a deprecation warninig when spinning up a new instance

### DIFF
--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -50,7 +50,7 @@ module Kitchen
         end
 
         def create_instance(options)
-          resource.create_instances(options)[0]
+          resource.create_instances(options).first
         end
 
         def get_instance(id)


### PR DESCRIPTION
AWS SDK V3 doesn't allow this anymore. See https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/resources/collection.rb#L38

Signed-off-by: Tim Smith <tsmith@chef.io>