### PR TITLE
Security Group Filter Enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,16 +210,31 @@ automatically which allows SSH and WinRM (**>= 2.1.0**).
 
 #### `security_group_filter`
 
-The EC2 [security group][group_docs] which will be applied to the instance,
-specified by tag. Only one group can be specified this way.
+The EC2 [security group(s)][group_docs] which will be applied to the instance,
+specified by name or tag. One or more groups can be specified.
 
 The default is unset, or `nil`.
 
 An example of usage:
 ```yaml
+# By Name
+security_group_filter:
+  name:   'example-group-name'
+
+# By Tag
 security_group_filter:
   tag:   'Name'
   value: 'example-group-name'
+
+# Multiple Groups
+security_group_filter:
+  - name: 'AWS-Egress'
+  - tag: 'Name'
+    value: 'MyApplicationSG'
+  - tag: 'Name'
+    value: 'MyApplicationDatabaseSG'
+  - tag: 'Name'
+    value: 'MyOtherSG'
 ```
 
 ### `security_group_cidr_ip`

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -89,8 +89,7 @@ module Kitchen
               if security_group
                 security_groups.push(security_group.group_id)
               else
-                raise "The group tagged '#{sg_filter[:tag]} " +
-                  "#{sg_filter[:value]}' does not exist!"
+                raise "A Security Group matching the following filter could not be found:\n#{sg_filter}"
               end
             end
             config[:security_group_ids] = security_groups

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -62,22 +62,38 @@ module Kitchen
           end
 
           if config[:security_group_ids].nil? && config[:security_group_filter]
-            security_group = ::Aws::EC2::Client
-                .new(region: config[:region]).describe_security_groups(
-                filters: [
-                    {
-                        name: "tag:#{config[:security_group_filter][:tag]}",
-                        values: [config[:security_group_filter][:value]],
-                    },
+            security_groups = []
+            filters = [config[:security_group_filter]].flatten
+            filters.each do |sg_filter|
+              r = {}
+              if sg_filter[:name]
+                r[:filters] = [
+                  {
+                    name: "group-name",
+                    values: [sg_filter[:name]],
+                  },
                 ]
-            )[0][0]
+              end
 
-            if security_group
-              config[:security_group_ids] = [security_group.group_id]
-            else
-              raise "The group tagged '#{config[:security_group_filter][:tag]} " +
-                "#{config[:security_group_filter][:value]}' does not exist!"
+              if sg_filter[:tag]
+                r[:filters] = [
+                  {
+                    name: "tag:#{sg_filter[:tag]}",
+                    values: [sg_filter[:value]],
+                  },
+                ]
+              end
+
+              security_group = ::Aws::EC2::Client.new(region: config[:region]).describe_security_groups(r)[0][0]
+
+              if security_group
+                security_groups.push(security_group.group_id)
+              else
+                raise "The group tagged '#{sg_filter[:tag]} " +
+                  "#{sg_filter[:value]}' does not exist!"
+              end
             end
+            config[:security_group_ids] = security_groups
           end
 
           i = {

--- a/spec/kitchen/driver/aws/instance_generator_spec.rb
+++ b/spec/kitchen/driver/aws/instance_generator_spec.rb
@@ -240,8 +240,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           ]
         ).and_return(ec2_stub_whithout_security_group.describe_security_groups)
 
-        expect { generator.ec2_instance_data }.to raise_error("The group tagged '#{config[:security_group_filter][:tag]} " +
-                                                              "#{config[:security_group_filter][:value]}' does not exist!")
+        expect { generator.ec2_instance_data }.to raise_error(
+          "A Security Group matching the following filter could not be found:\n#{config[:security_group_filter]}"
+        )
       end
     end
 


### PR DESCRIPTION
Adds support for searching for multiple groups, as well as searching by group name.  Sometimes SG's get created without tags, but they will always have a name.

Also, in a large enterprise environment you may need to leverage multiple security groups.  Using a list of search patterns is more readable and potentially portable across the account boundary.

This lets you do this:
```yaml
  security_group_filter:
    - name: 'AWS-Egress'
    - tag: 'Name'
      value: 'MyApplicationSG'
    - tag: 'Name'
      value: 'MyApplicationDatabaseSG'
    - tag: 'Name'
      value: 'MyOtherSG'
```
Instead of this
```yaml
security_group_ids:
  - sg-abc12345657891011
  - sg-accxsdsl2130dkj213
  - sg-0aabc123412321232
```

The code is backwards compatible with pre-existing `security_group_filter` functionality.