### PR TITLE
Add support for SSH through Session Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ The place from which to derive the hostname for communicating with the instance.
 2. Public IP Address
 3. Private IP Address
 4. Private DNS Name
-5. Instance ID (Useful for [SSH through Session Manger][ssh_over_ssm])
+5. Instance ID (Useful for [SSH through Session Manager][ssh_over_ssm])
 
 The default is unset. Under normal circumstances, the lookup will return the `Private IP Address`.
 

--- a/README.md
+++ b/README.md
@@ -401,12 +401,13 @@ If you don't set this it will default to whatever DHCP address EC2 hands out.
 
 #### `interface`
 
-The place from which to derive the hostname for communicating with the instance.  May be `dns`, `public`, `private` or `private_dns`.  If this is unset, the driver will derive the hostname by failing back in the following order:
+The place from which to derive the hostname for communicating with the instance.  May be `dns`, `public`, `private`, `private_dns` or `id`.  If this is unset, the driver will derive the hostname by failing back in the following order:
 
 1. DNS Name
 2. Public IP Address
 3. Private IP Address
 4. Private DNS Name
+5. Instance ID (Useful for [SSH through Session Manger][ssh_over_ssm])
 
 The default is unset. Under normal circumstances, the lookup will return the `Private IP Address`.
 
@@ -503,4 +504,5 @@ Apache 2.0 (see [LICENSE][license])
 [kitchenci]:        https://kitchen.ci/
 [region_docs]:      https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
 [subnet_docs]:      https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html
+[ssh_over_ssm]:     https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html
 [vpc_docs]:         https://docs.aws.amazon.com/AmazonVPC/latest/GettingStartedGuide/ExerciseOverview.html

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -647,6 +647,7 @@ module Kitchen
           "public" => "public_ip_address",
           "private" => "private_ip_address",
           "private_dns" => "private_dns_name",
+          "id" => "id",
         }.freeze
 
       #

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -109,12 +109,14 @@ describe Kitchen::Driver::Ec2 do
     let(:private_dns_name) { nil }
     let(:public_ip_address) { nil }
     let(:private_ip_address) { nil }
+    let(:id) { nil }
     let(:server) do
       double("server",
         public_dns_name: public_dns_name,
         private_dns_name: private_dns_name,
         public_ip_address: public_ip_address,
-        private_ip_address: private_ip_address
+        private_ip_address: private_ip_address,
+        id: id
       )
     end
 
@@ -138,6 +140,9 @@ describe Kitchen::Driver::Ec2 do
       end
       it "returns private_dns_name when requested" do
         expect(driver.hostname(server, "private_dns")).to eq(private_dns_name)
+      end
+      it "returns id when requested" do
+        expect(driver.hostname(server, "id")).to eq(id)
       end
     end
 


### PR DESCRIPTION
It is possible to SSH through an AWS Session Manager session[1]. The
best way to achieve this is to connect using the AWS instance ID as the
destination with a `ProxyCommand` configured for SSH.

[1]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html