### PR TITLE
Allow for retryable 3.0

### DIFF
--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "excon"
   gem.add_dependency "multi_json"
   gem.add_dependency "aws-sdk-ec2", "~> 1.0"
-  gem.add_dependency "retryable", "~> 2.0"
+  gem.add_dependency "retryable", ">= 2.0", "< 4.0" # 4.0 will need to be validated
 
   gem.add_development_dependency "rspec",     "~> 3.2"
   gem.add_development_dependency "countloc",  "~> 0.4"


### PR DESCRIPTION
3.0 just drops Ruby 1.8 support and then 3.0.x fixes some bugs. This is
holding back the dep in DK / Workstation.

Signed-off-by: Tim Smith <tsmith@chef.io>