### PR TITLE
Ignore case when checking if the instance provisioner is Chef

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -277,7 +277,7 @@ module Kitchen
 
         info("EC2 instance <#{state[:server_id]}> ready (hostname: #{state[:hostname]}).")
         instance.transport.connection(state).wait_until_ready
-        create_ec2_json(state) if instance.provisioner.name =~ /chef/
+        create_ec2_json(state) if instance.provisioner.name =~ /chef/i
         debug("ec2:create '#{state[:hostname]}'")
       rescue Exception
         # Clean up any auto-created security groups or keys on the way out.

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -788,6 +788,7 @@ module Kitchen
                  elsif config[:subnet_filter]
                    subnets = ec2.client.describe_subnets(filters: [{ name: "tag:#{config[:subnet_filter][:tag]}", values: [config[:subnet_filter][:value]] }]).subnets
                    raise "Subnets with tag '#{config[:subnet_filter][:tag]}=#{config[:subnet_filter][:value]}' not found during security group creation" if subnets.empty?
+
                    subnets.first.vpc_id
                  else
                    # Try to check for a default VPC.


### PR DESCRIPTION
**Changes:**
- Ignores the case of "chef" when determining if the instance provisioner is Chef. 
- Added some whitespace to make rubocop happy so the build passes.

I noticed this issue when the 'ec2' node attributes weren't being populated by ohai, despite using the EC2 driver.

The `.name` method (defined in configurable [here](https://github.com/test-kitchen/test-kitchen/blob/651069f731bc8f87a9ca6948114e5ab81e814a4e/lib/kitchen/configurable.rb#L139)), is based on the class name of the provisioner, which is generally going to be capitalized.

