### PR TITLE
Don't crash upon destroy if instance is already dead

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -291,7 +291,11 @@ module Kitchen
           server = ec2.get_instance(state[:server_id])
           unless server.nil?
             instance.transport.connection(state).close
-            server.terminate
+            begin
+              server.terminate
+            rescue ::Aws::EC2::Errors::InvalidInstanceIDNotFound => e
+              warn("Received #{e}, instance was probably already destroyed. Ignoring")
+            end
           end
           if state[:spot_request_id]
             debug("Deleting spot request <#{state[:server_id]}>")


### PR DESCRIPTION
On some environment, instances are automatically destroyed after a while
(to avoid leaking test instance that would be billed for a long time).

This patch, ignore errors from ec2 when instance id is not found upon
destroy.

It will solve the long running issue where user runs `kitchen test` >1d
after running a `kitchen test --destroy=never` for instance

This is a cherry-pick of https://github.com/criteo-forks/kitchen-ec2/pull/8/commits to latest kitchen-ec2 version

Change-Id: I331c01b43c5797426361d0268f3feefc88d1e8ce