### PR TITLE
Use multiple results from subnet_filter for spot requests

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -446,6 +446,7 @@ module Kitchen
       end
 
       def submit_spots(state)
+        instance_generator.subnet_filter_to_subnet_ids
         configs = [config]
         expanded = []
         keys = %i{instance_type subnet_id}


### PR DESCRIPTION
We were having issues finding spot capacity for our test instances because the launch specification was only using the first result from `subnet_filter` searches.

I slightly reworked the `submit_spots` method to replace `config[:subnet_id]` with the results of the filter prior to expanding the configs.

I left the behavior within the `ec2_instance_data` method the same, i.e. it will continue to return the first result of the filter search.