### PR TITLE
Least Populated Subnet

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -56,8 +56,10 @@ module Kitchen
             ).subnets
             raise "The subnet tagged '#{config[:subnet_filter][:tag]}:#{config[:subnet_filter][:value]}' does not exist!" unless subnets.any?
 
-            vpc_id = subnets[0].vpc_id
-            config[:subnet_id] = subnets[0].subnet_id
+            # => Select the least-populated subnet if we have multiple matches
+            subnet = subnets.sort_by { |s| s[:available_ip_address_count] }.last
+            vpc_id = subnet.vpc_id
+            config[:subnet_id] = subnet.subnet_id
           end
 
           if config[:security_group_ids].nil? && config[:security_group_filter]


### PR DESCRIPTION
Select the least-populated subnet if we have multiple matches -- previously we just took the first match.

VPC may span multiple regions -- subnets are region specific.  This lets you pick the least populated VPC.

This should help to distribute the test-kitchen load more evenly across multi-az VPC's while maintaining full backward compatibility.

We've noticed intermittent problems internally with our cookbook generator where folks do not change the default (e.g.   org_*_dmz => always resolves to org_us-east-1a-dmz).  Kitchens sometimes fail either because of spot instance unavailability, ip starvation, etc.

@sumitag @chefbob @danielcbright