### PR TITLE
Make Debian 10 the Debian default

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --color
 --require spec_helper
---format progress
+--format documentation

--- a/lib/kitchen/driver/aws/standard_platform/debian.rb
+++ b/lib/kitchen/driver/aws/standard_platform/debian.rb
@@ -26,12 +26,13 @@ module Kitchen
           # 10/11 are listed last since we default to the first item in the hash
           # and 10/11 are not released yet. When they're released move them up
           DEBIAN_CODENAMES = {
+            10 => "buster",
             9 => "stretch",
             8 => "jessie",
             7 => "wheezy",
             6 => "squeeze",
             11 => "bullseye",
-            10 => "buster",
+            12 => "bookworm",
           }.freeze
 
           # default username for this platform's ami

--- a/spec/kitchen/driver/aws/image_selection_spec.rb
+++ b/spec/kitchen/driver/aws/image_selection_spec.rb
@@ -112,7 +112,11 @@ describe "Default images for various platforms" do
 
     "debian" => [
       { name: "owner-id", values: %w{379101102735} },
-      { name: "name", values: %w{debian-stretch-*} },
+      { name: "name", values: %w{debian-buster-*} },
+    ],
+    "debian-10" => [
+      { name: "owner-id", values: %w{379101102735} },
+      { name: "name", values: %w{debian-buster-*} },
     ],
     "debian-9" => [
       { name: "owner-id", values: %w{379101102735} },
@@ -136,7 +140,7 @@ describe "Default images for various platforms" do
     ],
     "debian-x86_64" => [
       { name: "owner-id", values: %w{379101102735} },
-      { name: "name", values: %w{debian-stretch-*} },
+      { name: "name", values: %w{debian-buster-*} },
       { name: "architecture", values: %w{x86_64} },
     ],
     "debian-6-x86_64" => [


### PR DESCRIPTION
Add the future codename for 12.

Signed-off-by: Tim Smith <tsmith@chef.io>