### PR TITLE
Tag on-demand instances at creation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ The Hash of EC tag name/value pairs which will be applied to the instance.
 
 The default is `{ "created-by" => "test-kitchen" }`.
 
-Tags are applied post creation for spot instances and during creation for standard instances.
 
 #### `user_data`
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ The Hash of EC tag name/value pairs which will be applied to the instance.
 
 The default is `{ "created-by" => "test-kitchen" }`.
 
+Tags are applied post creation for spot instances and during creation for standard instances.
+
 #### `user_data`
 
 The user_data script or the path to a script to feed the instance.

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -115,7 +115,21 @@ module Kitchen
             key_name: config[:aws_ssh_key_id],
             subnet_id: config[:subnet_id],
             private_ip_address: config[:private_ip_address],
+            min_count: 1,
+            max_count: 1,
           }
+
+          if config[:tags] && !config[:tags].empty?
+            tags = config[:tags].map do |k, v|
+              # we convert the value to a string because
+              # nils should be passed as an empty String
+              # and Integers need to be represented as Strings
+              { key: k, value: v.to_s }
+            end
+            instance_tag_spec = { resource_type: "instance", tags: tags }
+            volume_tag_spec = { resource_type: "volume", tags: tags }
+            i[:tag_specifications] = [instance_tag_spec, volume_tag_spec]
+          end
 
           availability_zone = config[:availability_zone]
           if availability_zone

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -418,6 +418,17 @@ module Kitchen
         end
         instance_data[:min_count] = 1
         instance_data[:max_count] = 1
+        if config[:tags] && !config[:tags].empty?
+          tags = config[:tags].map do |k, v|
+            # we convert the value to a string because
+            # nils should be passed as an empty String
+            # and Integers need to be represented as Strings
+            { :key => k, :value => v.to_s }
+          end
+          instance_tag_spec = { :resource_type => "instance", :tags => tags }
+          volume_tag_spec = { :resource_type => "volume", :tags => tags }
+          instance_data[:tag_specifications] = [instance_tag_spec, volume_tag_spec]
+        end
         ec2.create_instance(instance_data)
       end
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -423,10 +423,10 @@ module Kitchen
             # we convert the value to a string because
             # nils should be passed as an empty String
             # and Integers need to be represented as Strings
-            { :key => k, :value => v.to_s }
+            { key: k, value: v.to_s }
           end
-          instance_tag_spec = { :resource_type => "instance", :tags => tags }
-          volume_tag_spec = { :resource_type => "volume", :tags => tags }
+          instance_tag_spec = { resource_type: "instance", tags: tags }
+          volume_tag_spec = { resource_type: "volume", tags: tags }
           instance_data[:tag_specifications] = [instance_tag_spec, volume_tag_spec]
         end
         ec2.create_instance(instance_data)

--- a/spec/kitchen/driver/aws/instance_generator_spec.rb
+++ b/spec/kitchen/driver/aws/instance_generator_spec.rb
@@ -99,7 +99,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
         image_id: nil,
         key_name: nil,
         subnet_id: nil,
-        private_ip_address: nil
+        private_ip_address: nil,
+        max_count: 1,
+        min_count: 1
       )
     end
 
@@ -122,7 +124,42 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           image_id: "ami-123",
           key_name: nil,
           subnet_id: "s-456",
-          private_ip_address: "0.0.0.0"
+          private_ip_address: "0.0.0.0",
+          max_count: 1,
+          min_count: 1
+        )
+      end
+    end
+
+    context "when provided with tags" do
+      let(:config) do
+        {
+          region: "us-east-2",
+          tags: {
+            string_tag: "string",
+            integer_tag: 1,
+          },
+        }
+      end
+
+      it "includes tag specifications" do
+        expect(generator.ec2_instance_data).to include(
+          tag_specifications: [
+            {
+              resource_type: "instance",
+              tags: [
+                { key: :string_tag, value: "string" },
+                { key: :integer_tag, value: "1" },
+              ],
+            },
+            {
+              resource_type: "volume",
+              tags: [
+                { key: :string_tag, value: "string" },
+                { key: :integer_tag, value: "1" },
+              ],
+            },
+          ]
         )
       end
     end
@@ -147,7 +184,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           image_id: "ami-123",
           key_name: "key",
           subnet_id: "s-456",
-          private_ip_address: "0.0.0.0"
+          private_ip_address: "0.0.0.0",
+          max_count: 1,
+          min_count: 1
         )
       end
     end
@@ -288,7 +327,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           image_id: "ami-123",
           key_name: "key",
           subnet_id: "s-456",
-          private_ip_address: "0.0.0.0"
+          private_ip_address: "0.0.0.0",
+          max_count: 1,
+          min_count: 1
         )
       end
     end
@@ -308,7 +349,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           key_name: nil,
           subnet_id: nil,
           private_ip_address: nil,
-          placement: { availability_zone: "eu-west-1c" }
+          placement: { availability_zone: "eu-west-1c" },
+          max_count: 1,
+          min_count: 1
         )
       end
     end
@@ -328,7 +371,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           key_name: nil,
           subnet_id: nil,
           private_ip_address: nil,
-          placement: { availability_zone: "eu-east-1c" }
+          placement: { availability_zone: "eu-east-1c" },
+          max_count: 1,
+          min_count: 1
         )
       end
     end
@@ -346,7 +391,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           image_id: nil,
           key_name: nil,
           subnet_id: nil,
-          private_ip_address: nil
+          private_ip_address: nil,
+          max_count: 1,
+          min_count: 1
         )
       end
     end
@@ -367,6 +414,8 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           key_name: nil,
           subnet_id: nil,
           private_ip_address: nil,
+          max_count: 1,
+          min_count: 1,
           placement: { availability_zone: "eu-east-1c",
                        tenancy: "dedicated" }
         )
@@ -388,7 +437,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           key_name: nil,
           subnet_id: nil,
           private_ip_address: nil,
-          placement: { tenancy: "default" }
+          placement: { tenancy: "default" },
+          max_count: 1,
+          min_count: 1
         )
       end
     end
@@ -409,6 +460,8 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           key_name: nil,
           subnet_id: nil,
           private_ip_address: nil,
+          max_count: 1,
+          min_count: 1,
           placement: { availability_zone: "eu-east-1c",
                        tenancy: "dedicated" }
         )
@@ -430,7 +483,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           key_name: nil,
           subnet_id: nil,
           private_ip_address: nil,
-          placement: { tenancy: "default" }
+          placement: { tenancy: "default" },
+          max_count: 1,
+          min_count: 1
         )
       end
     end
@@ -450,7 +505,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           image_id: nil,
           key_name: nil,
           subnet_id: "s-456",
-          private_ip_address: nil
+          private_ip_address: nil,
+          max_count: 1,
+          min_count: 1
         )
       end
     end
@@ -475,7 +532,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
             device_index: 0,
             associate_public_ip_address: true,
             delete_on_termination: true,
-          }]
+          }],
+          max_count: 1,
+          min_count: 1
         )
       end
 
@@ -500,7 +559,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
               associate_public_ip_address: true,
               delete_on_termination: true,
               subnet_id: "s-456",
-            }]
+            }],
+            max_count: 1,
+            min_count: 1
           )
         end
       end
@@ -527,7 +588,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
               associate_public_ip_address: true,
               delete_on_termination: true,
               groups: ["sg-789"],
-            }]
+            }],
+            max_count: 1,
+            min_count: 1
           )
         end
 
@@ -566,7 +629,9 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
               associate_public_ip_address: true,
               delete_on_termination: true,
               private_ip_address: "0.0.0.0",
-            }]
+            }],
+            max_count: 1,
+            min_count: 1
           )
         end
       end
@@ -599,6 +664,10 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
           user_data: "foo",
           iam_profile_name: "iam-123",
           associate_public_ip: true,
+          tags: {
+            string_tag: "string",
+            integer_tag: 1,
+          },
         }
       end
 
@@ -630,7 +699,25 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
             private_ip_address: "0.0.0.0",
           }],
           placement: { availability_zone: "eu-west-1a" },
-          user_data: Base64.encode64("foo")
+          user_data: Base64.encode64("foo"),
+          max_count: 1,
+          min_count: 1,
+          tag_specifications: [
+            {
+              resource_type: "instance",
+              tags: [
+                { key: :string_tag, value: "string" },
+                { key: :integer_tag, value: "1" },
+              ],
+            },
+            {
+              resource_type: "volume",
+              tags: [
+                { key: :string_tag, value: "string" },
+                { key: :integer_tag, value: "1" },
+              ],
+            },
+          ]
         )
       end
     end

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -35,18 +35,6 @@ describe Kitchen::Driver::Ec2 do
       security_group_ids: ["sg-56789"],
     }
   end
-  let(:tag_spec) do
-    [
-      {
-        resource_type: "instance",
-        tags: [ { key: "created-by", value: "test-kitchen" } ],
-      },
-      {
-        resource_type: "volume",
-        tags: [ { key: "created-by", value: "test-kitchen" } ],
-      },
-    ]
-  end
   let(:platform)      { Kitchen::Platform.new(name: "fooos-99") }
   let(:transport)     { Kitchen::Transport::Dummy.new }
   let(:provisioner)   { Kitchen::Provisioner::Dummy.new }
@@ -242,7 +230,7 @@ describe Kitchen::Driver::Ec2 do
 
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
-      expect(client).to receive(:create_instance).with(min_count: 1, max_count: 1, tag_specifications: tag_spec)
+      expect(client).to receive(:create_instance)
       driver.submit_server
     end
   end
@@ -258,18 +246,13 @@ describe Kitchen::Driver::Ec2 do
         instance_initiated_shutdown_behavior: "terminate"
       )
       expect(client).to receive(:create_instance).with(
-        min_count: 1, max_count: 1, instance_initiated_shutdown_behavior: "terminate", tag_specifications: tag_spec
+        instance_initiated_shutdown_behavior: "terminate"
       )
       driver.submit_server
     end
   end
 
   describe "#submit_spot" do
-    let(:state) { {} }
-    let(:response) do
-      { spot_instance_requests: [{ spot_instance_request_id: "id" }] }
-    end
-
     before do
       expect(driver).to receive(:instance).at_least(:once).and_return(instance)
       allow(Time).to receive(:now).and_return(Time.now)
@@ -277,119 +260,19 @@ describe Kitchen::Driver::Ec2 do
 
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
-      expect(actual_client).to receive(:request_spot_instances).with(
-        spot_price: "",
-        launch_specification: {},
-        valid_until: Time.now + config[:spot_wait],
-        block_duration_minutes: 60
-      ).and_return(response)
-      expect(actual_client).to receive(:wait_until)
-      expect(client).to receive(:get_instance_from_spot_request).with("id")
-      driver.submit_spot(state)
-      expect(state).to eq(spot_request_id: "id")
-    end
-  end
-
-  describe "#tag_server" do
-    context "with no tags specified" do
-      it "does not raise" do
-        config[:tags] = nil
-        expect { driver.tag_server(server) }.not_to raise_error
-      end
-    end
-
-    context "with standard string tags" do
-      it "tags the server" do
-        config[:tags] = { key1: "value1", key2: "value2" }
-        expect(server).to receive(:create_tags).with(
-          tags: [
-            { key: "key1", value: "value1" },
-            { key: "key2", value: "value2" },
-          ]
-        )
-        driver.tag_server(server)
-      end
-      it "tags the server with String keys" do
-        config[:tags] = { key1: "value1", "key2" => "value2" }
-        expect(server).to receive(:create_tags).with(
-          tags: [
-            { key: "key1", value: "value1" },
-            { key: "key2", value: "value2" },
-          ]
-        )
-        driver.tag_server(server)
-      end
-    end
-
-    context "with a tag that includes a Integer value" do
-      it "tags the server" do
-        config[:tags] = { key1: "value1", key2: 1 }
-        expect(server).to receive(:create_tags).with(
-          tags: [
-            { key: "key1", value: "value1" },
-            { key: "key2", value: "1" },
-          ]
-        )
-        driver.tag_server(server)
-      end
-    end
-
-    context "with a tag that includes a Nil value" do
-      it "tags the server" do
-        config[:tags] = { key1: "value1", key2: nil }
-        expect(server).to receive(:create_tags).with(
-          tags: [
-            { key: "key1", value: "value1" },
-            { key: "key2", value: "" },
-          ]
-        )
-        driver.tag_server(server)
-      end
-    end
-  end
-
-  describe "#tag_volumes" do
-    let(:volume) { double("aws volume resource") }
-    before do
-      allow(server).to receive(:volumes).and_return([volume])
-    end
-    context "with standard string tags" do
-      it "tags the instance volumes" do
-        config[:tags] = { key1: "value1", key2: "value2" }
-        expect(volume).to receive(:create_tags).with(
-          tags: [
-            { key: "key1", value: "value1" },
-            { key: "key2", value: "value2" },
-          ]
-        )
-        driver.tag_volumes(server)
-      end
-    end
-
-    context "with a tag that includes a Integer value" do
-      it "tags the instance volumes" do
-        config[:tags] = { key1: "value1", key2: 2 }
-        expect(volume).to receive(:create_tags).with(
-          tags: [
-            { key: "key1", value: "value1" },
-            { key: "key2", value: "2" },
-          ]
-        )
-        driver.tag_volumes(server)
-      end
-    end
-
-    context "with a tag that includes a Nil value" do
-      it "tags the instance volumes" do
-        config[:tags] = { key1: "value1", key2: nil }
-        expect(volume).to receive(:create_tags).with(
-          tags: [
-            { key: "key1", value: "value1" },
-            { key: "key2", value: "" },
-          ]
-        )
-        driver.tag_volumes(server)
-      end
+      expect(client).to receive(:create_instance).with(
+        instance_market_options: {
+          market_type: "spot",
+          spot_options: {
+            max_price: "", # TODO: @cwolfe
+            spot_instance_type: "persistent",
+            instance_interruption_behavior: "stop",
+            valid_until: Time.now + config[:spot_wait],
+            block_duration_minutes: 60,
+          },
+        }
+      ).and_return(server)
+      driver.submit_spot
     end
   end
 
@@ -432,40 +315,6 @@ describe Kitchen::Driver::Ec2 do
         expect(aws_instance).to receive(:exists?).and_return(true)
         expect(aws_instance).to receive_message_chain("state.name").and_return("running")
         expect(driver.wait_until_ready(server, state)).to eq(true)
-      end
-    end
-  end
-
-  describe "#wait_until_volumes_ready" do
-    let(:aws_instance) { double("aws instance") }
-    let(:msg) { "volumes to be ready" }
-    let(:volume) { double("aws volume resource") }
-
-    before do
-      expect(driver).to receive(:wait_with_destroy).with(server, state, msg).and_yield(aws_instance)
-    end
-    it "first checks instance existence" do
-      expect(aws_instance).to receive(:exists?).and_return(false)
-      expect(driver.wait_until_volumes_ready(server, state)).to eq(false)
-    end
-    it "second, it checks for prescence of described volumes" do
-      expect(aws_instance).to receive(:exists?).and_return(true)
-      expect(actual_client).to receive_message_chain(:describe_volumes, :volumes, :length).and_return(0)
-      expect(aws_instance).to receive(:volumes).and_return([])
-      expect(driver.wait_until_volumes_ready(server, state)).to eq(false)
-    end
-    it "third, it compares the described volumes and instance volumes" do
-      expect(aws_instance).to receive(:exists?).and_return(true)
-      expect(actual_client).to receive_message_chain(:describe_volumes, :volumes, :length).and_return(2)
-      expect(aws_instance).to receive(:volumes).and_return([volume])
-      expect(driver.wait_until_volumes_ready(server, state)).to eq(false)
-    end
-    context "when it exists, and both client and instance agree on volumes" do
-      it "returns true" do
-        expect(aws_instance).to receive(:exists?).and_return(true)
-        expect(actual_client).to receive_message_chain(:describe_volumes, :volumes, :length).and_return(1)
-        expect(aws_instance).to receive(:volumes).and_return([volume])
-        expect(driver.wait_until_volumes_ready(server, state)).to eq(true)
       end
     end
   end
@@ -571,11 +420,7 @@ describe Kitchen::Driver::Ec2 do
       it "successfully creates and tags the instance" do
         expect(server).to receive(:wait_until_exists)
         expect(driver).to receive(:update_username)
-        expect(driver).to receive(:tag_server).with(server)
-        expect(driver).to receive(:tag_volumes).with(server)
-        expect(driver).to receive(:wait_until_volumes_ready).with(server, state)
         expect(driver).to receive(:wait_until_ready).with(server, state)
-        allow(actual_client).to receive(:describe_images).with({ image_ids: [server.image_id] }).and_return(ec2_stub)
         expect(transport).to receive_message_chain("connection.wait_until_ready")
         driver.create(state)
         expect(state[:server_id]).to eq(id)
@@ -608,7 +453,7 @@ describe Kitchen::Driver::Ec2 do
 
       context "price is numeric" do
         before do
-          expect(driver).to receive(:submit_spots).with(state).and_return(server)
+          expect(driver).to receive(:submit_spots).and_return(server)
         end
 
         include_examples "common create"
@@ -617,7 +462,7 @@ describe Kitchen::Driver::Ec2 do
       context "price is on-demand" do
         before do
           config[:spot_price] = "on-demand"
-          expect(driver).to receive(:submit_spots).with(state).and_return(server)
+          expect(driver).to receive(:submit_spots).and_return(server)
         end
 
         include_examples "common create"
@@ -626,7 +471,7 @@ describe Kitchen::Driver::Ec2 do
       context "instance_type is an array" do
         before do
           config[:instance_type] = %w{t1 t2}
-          expect(driver).to receive(:submit_spot).with(state).and_return(server)
+          expect(driver).to receive(:submit_spot).and_return(server)
         end
 
         include_examples "common create"
@@ -638,21 +483,6 @@ describe Kitchen::Driver::Ec2 do
 
           include_examples "common create"
         end
-      end
-    end
-
-    context "instance is not ebs-backed" do
-      before do
-        ec2_stub.images[0].root_device_type = "instance-store"
-      end
-
-      it "does not tag volumes or wait for volumes to be ready" do
-        expect(driver).to_not receive(:tag_volumes).with(server)
-        expect(driver).to_not receive(:wait_until_volumes_ready).with(server, state)
-      end
-
-      after do
-        ec2_stub.images[0].root_device_type = "ebs"
       end
     end
 
@@ -829,38 +659,6 @@ describe Kitchen::Driver::Ec2 do
         include_examples "common create"
       end
     end
-
-    context "and setting tags" do
-      let(:tag_spec) do
-        [
-          {
-            resource_type: "instance",
-            tags: [
-              { key: "string", value: "a_string" },
-              { key: "integer", value: "1" },
-            ],
-          },
-          {
-            resource_type: "volume",
-            tags: [
-              { key: "string", value: "a_string" },
-              { key: "integer", value: "1" },
-            ],
-          },
-        ]
-      end
-
-      before do
-        config[:tags] = {
-          "string" => "a_string",
-          "integer" => 1,
-        }
-        expect(generator).to receive(:ec2_instance_data).and_return({})
-        expect(client).to receive(:create_instance).with(max_count: 1, min_count: 1, tag_specifications: tag_spec).and_return(server)
-      end
-
-      include_examples "common create"
-    end
   end
 
   describe "#destroy" do
@@ -885,21 +683,6 @@ describe Kitchen::Driver::Ec2 do
         expect(client).to receive(:get_instance).with("id").and_return(server)
         expect(instance).to receive_message_chain("transport.connection.close")
         expect(server).to receive(:terminate)
-        driver.destroy(state)
-        expect(state).to eq({})
-      end
-    end
-
-    context "when state has a spot request" do
-      let(:state) { { server_id: "id", hostname: "name", spot_request_id: "spot" } }
-
-      it "destroys the server" do
-        expect(client).to receive(:get_instance).with("id").and_return(server)
-        expect(instance).to receive_message_chain("transport.connection.close")
-        expect(server).to receive(:terminate)
-        expect(actual_client).to receive(:cancel_spot_instance_requests).with(
-          spot_instance_request_ids: ["spot"]
-        )
         driver.destroy(state)
         expect(state).to eq({})
       end

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -264,7 +264,6 @@ describe Kitchen::Driver::Ec2 do
         instance_market_options: {
           market_type: "spot",
           spot_options: {
-            max_price: "", # TODO: @cwolfe
             spot_instance_type: "persistent",
             instance_interruption_behavior: "stop",
             valid_until: Time.now + config[:spot_wait],

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -230,7 +230,7 @@ describe Kitchen::Driver::Ec2 do
 
     it "submits the server request" do
       expect(generator).to receive(:ec2_instance_data).and_return({})
-      expect(client).to receive(:create_instance).with(min_count: 1, max_count: 1)
+      expect(client).to receive(:create_instance).with(min_count: 1, max_count: 1, tag_specifications: anything)
       driver.submit_server
     end
   end
@@ -246,7 +246,7 @@ describe Kitchen::Driver::Ec2 do
         instance_initiated_shutdown_behavior: "terminate"
       )
       expect(client).to receive(:create_instance).with(
-        min_count: 1, max_count: 1, instance_initiated_shutdown_behavior: "terminate"
+        min_count: 1, max_count: 1, instance_initiated_shutdown_behavior: "terminate", tag_specifications: anything
       )
       driver.submit_server
     end


### PR DESCRIPTION
# Description

This is started as an adoption of #414 by @sumitag, adding tests and rebasing. #414 applies tags at instance creation time to on-demand instances. 

This PR then goes on to convert spot instance requests to use the `create_instances()` API call, which allows tagging at creation time. This allows all tagging to happen at creation time, so all post-hoc tagging code is removed.

There are some fallout effects from using `create_instances()` instead of `spot_instance_request()`:
 * Since it is not a spot instance request, the is no Spot Instance Request ID to report to the user.
 * Spot Instance Requests internally retry the request until it succeeds or the request expires. `create_instances()` is one-shot, so kitchen-ec2 must explicitly retry the call.
 * ~There is a feature that allows the user to set the spot price to "on-demand" to get the on-demand price; internally this sets the bid price to an empty string. This is not allowed in the `create_instances()` API. **Currently this is not solved, and the feature is broken pending discussion.**~ Update: When on-demand is specified, the max_price field may simply be omitted, causing the bid price to be set to the on-demand price.

## Issues Resolved

Fixes #360 
Fixes #480 
Fixes #464

I suggest PRs #364 and #414 be closed.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
