### PR TITLE
Improvements to CentOS Image search

### DIFF
--- a/lib/kitchen/driver/aws/standard_platform/centos.rb
+++ b/lib/kitchen/driver/aws/standard_platform/centos.rb
@@ -23,6 +23,13 @@ module Kitchen
         class Centos < StandardPlatform
           StandardPlatform.platforms["centos"] = self
 
+          PRODUCT_CODES = {
+            "6" => "6x5jmcajty9edm3f211pqjfn2",
+            "7" => "aw0evgkw8e5c1q413zgy5pjce",
+            # It appears that v8 is not published to the
+            # AWS marketplace and hence does not have a product code
+          }.freeze
+
           # default username for this platform's ami
           # @return [String]
           def username
@@ -38,6 +45,14 @@ module Kitchen
               "owner-alias" => "aws-marketplace",
               "name" => ["CentOS Linux #{version}*", "CentOS-#{version}*-GA-*"],
             }
+            # Additionally filter on product code if known for major version to
+            # avoid non-official AMIs
+            # https://github.com/test-kitchen/kitchen-ec2/issues/456
+            if version
+              PRODUCT_CODES.keys.each do |major_version|
+                search["product-code"] = PRODUCT_CODES[major_version] if version.start_with?(major_version)
+              end
+            end
             search["architecture"] = architecture if architecture
             search
           end

--- a/spec/kitchen/driver/aws/image_selection_spec.rb
+++ b/spec/kitchen/driver/aws/image_selection_spec.rb
@@ -79,8 +79,12 @@ describe "Default images for various platforms" do
     ],
 
     "centos" => [
-      { name: "owner-alias", values: %w{aws-marketplace} },
-      { name: "name", values: ["CentOS Linux *", "CentOS-*-GA-*"] },
+      { name: "owner-id", values: %w{125523088429} },
+      { name: "name", values: ["CentOS *", "CentOS-*-GA-*"] },
+    ],
+    "centos-8" => [
+      { name: "owner-id", values: %w{125523088429} },
+      { name: "name", values: ["CentOS 8*", "CentOS-8*-GA-*"] },
     ],
     "centos-7" => [
       { name: "owner-alias", values: %w{aws-marketplace} },
@@ -98,8 +102,8 @@ describe "Default images for various platforms" do
       { name: "product-code", values: ["6x5jmcajty9edm3f211pqjfn2"] },
     ],
     "centos-x86_64" => [
-      { name: "owner-alias", values: %w{aws-marketplace} },
-      { name: "name", values: ["CentOS Linux *", "CentOS-*-GA-*"] },
+      { name: "owner-id", values: %w{125523088429} },
+      { name: "name", values: ["CentOS *", "CentOS-*-GA-*"] },
       { name: "architecture", values: %w{x86_64} },
     ],
     "centos-6.3-x86_64" => [

--- a/spec/kitchen/driver/aws/image_selection_spec.rb
+++ b/spec/kitchen/driver/aws/image_selection_spec.rb
@@ -85,14 +85,17 @@ describe "Default images for various platforms" do
     "centos-7" => [
       { name: "owner-alias", values: %w{aws-marketplace} },
       { name: "name", values: ["CentOS Linux 7*", "CentOS-7*-GA-*"] },
+      { name: "product-code", values: ["aw0evgkw8e5c1q413zgy5pjce"] },
     ],
     "centos-6" => [
       { name: "owner-alias", values: %w{aws-marketplace} },
       { name: "name", values: ["CentOS Linux 6*", "CentOS-6*-GA-*"] },
+      { name: "product-code", values: ["6x5jmcajty9edm3f211pqjfn2"] },
     ],
     "centos-6.3" => [
       { name: "owner-alias", values: %w{aws-marketplace} },
       { name: "name", values: ["CentOS Linux 6.3*", "CentOS-6.3*-GA-*"] },
+      { name: "product-code", values: ["6x5jmcajty9edm3f211pqjfn2"] },
     ],
     "centos-x86_64" => [
       { name: "owner-alias", values: %w{aws-marketplace} },
@@ -102,11 +105,13 @@ describe "Default images for various platforms" do
     "centos-6.3-x86_64" => [
       { name: "owner-alias", values: %w{aws-marketplace} },
       { name: "name", values: ["CentOS Linux 6.3*", "CentOS-6.3*-GA-*"] },
+      { name: "product-code", values: ["6x5jmcajty9edm3f211pqjfn2"] },
       { name: "architecture", values: %w{x86_64} },
     ],
     "centos-7-x86_64" => [
       { name: "owner-alias", values: %w{aws-marketplace} },
       { name: "name", values: ["CentOS Linux 7*", "CentOS-7*-GA-*"] },
+      { name: "product-code", values: ["aw0evgkw8e5c1q413zgy5pjce"] },
       { name: "architecture", values: %w{x86_64} },
     ],
 


### PR DESCRIPTION
# Description

Two small fixes to the CentOS image search.

First, addressing #456, add an additional filter to the search when looking for CentOS 6 or 7 images to also filter on the ProductCode. This extra field ensures that the AMI returned is the official CentOS image, not an image created by another provider who happened to name their image "CentOS Linux".

That approach did not work for CentOS 8, however. It was found that CentOS 8 is not published to the AWS Marketplace; while the images are still public.  Additionally, the Name string had changed slightly, causing the search based on "CentOS Linux" to never match centos-8. For CentOS 8+, the Name match is adjusted, and we use the OwnerID to match the publisher of the image.

Specifying simply "centos" will now provide the latest centos-8 image, as expected; previously it would provide the latest centos-7 image.

Search tested on centos 6,7,8 on regions us-east-1, us-east-2, and us-west-2.

Unit tests updated.

## Issues Resolved

Fixes #456 
Closes chef/chef-workstation#1311

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
