### PR TITLE
Prefer non-Beta RHEL AMIs in search; remove encoding comments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:test)

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "kitchen/driver/ec2_version.rb"

--- a/lib/kitchen/driver/aws/client.rb
+++ b/lib/kitchen/driver/aws/client.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #

--- a/lib/kitchen/driver/aws/standard_platform/rhel.rb
+++ b/lib/kitchen/driver/aws/standard_platform/rhel.rb
@@ -50,6 +50,13 @@ module Kitchen
               new(driver, "rhel", (Regexp.last_match || [])[1], image.architecture)
             end
           end
+
+          def sort_by_version(images)
+            # First do a normal version sort
+            super(images)
+            # Now sort again, shunning Beta releases.
+            prefer(images) { |image| !image.name.match(/_Beta-/i) }
+          end
         end
       end
     end

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/driver/aws/client_spec.rb
+++ b/spec/kitchen/driver/aws/client_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #

--- a/spec/kitchen/driver/aws/instance_generator_spec.rb
+++ b/spec/kitchen/driver/aws/instance_generator_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #

--- a/spec/kitchen/driver/aws/standard_platform_spec.rb
+++ b/spec/kitchen/driver/aws/standard_platform_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #


### PR DESCRIPTION
# Description

When searching for RHEL AMIs, this change alters the search sort so that Beta AMIs are sorted after non-Beta (GA) AMIs. This has the effect of making it so that searches for `rhel-7` will return RHEL 7.8 rather than RHEL 7.9 Beta, which is the expected behavior. 

To obtain RHEL 7.9, search explicitly for `rhel-7.9` - that will cause all search results to be Beta, in which case this search sort change will have no effect.

Also includes a drive-by Chefstyle update for removing the encoding comments, on a separate commit.

## Issues Resolved

Fixes #505

Closes chef/chef-workstation#1410

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
