### PR TITLE
Use match? instead of =~ to reduce memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 ## [v3.0.0](https://github.com/test-kitchen/kitchen-ec2/tree/v3.0.0) (2019-05-01)
 [Full Changelog](https://github.com/test-kitchen/kitchen-ec2/compare/v2.4.0..v3.0.0)
 
-- Switch from the monolithic aws-sdk-v2 to the just aws-sdk-ec2 aka aws-sdk-v3. This greatly reduces the number of dependencies necessary for this plugin, but is a major change that makes it incompatible with older released of Chef-DK that require aws-sdk-v2.
+- Switch from the monolithic aws-sdk-v2 to the just aws-sdk-ec2 aka aws-sdk-v3. This greatly reduces the number of dependencies necessary for this plugin, but is a major change that makes it incompatible with older released of ChefDK that require aws-sdk-v2.
 - Require Ruby 2.3 or later as Ruby 2.2 is now EOL
 - Loosen the dependency on Test Kitchen to allow this plugin to work with Test Kitchen 2.0
 - Fix hostname detection to not fail when the system doesn't have a public IP. Thanks [@niekrasp](https://github.com/niekrasp)
@@ -297,7 +297,7 @@
 
 **Closed issues:**
 
-- Requesting to include this plug-in in Chefdk [\#218](https://github.com/test-kitchen/kitchen-ec2/issues/218)
+- Requesting to include this plug-in in ChefDK [\#218](https://github.com/test-kitchen/kitchen-ec2/issues/218)
 - Can't ssh to instance after it's created [\#217](https://github.com/test-kitchen/kitchen-ec2/issues/217)
 - No installation instructions [\#216](https://github.com/test-kitchen/kitchen-ec2/issues/216)
 - availability\_zone is always b [\#215](https://github.com/test-kitchen/kitchen-ec2/issues/215)

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -132,7 +132,7 @@ module Kitchen
 
           availability_zone = config[:availability_zone]
           if availability_zone
-            if availability_zone =~ /^[a-z]$/i
+            if /^[a-z]$/i.match?(availability_zone)
               availability_zone = "#{config[:region]}#{availability_zone}"
             end
             i[:placement] = { availability_zone: availability_zone.downcase }
@@ -175,7 +175,7 @@ module Kitchen
           end
           availability_zone = config[:availability_zone]
           if availability_zone
-            if availability_zone =~ /^[a-z]$/i
+            if /^[a-z]$/i.match?(availability_zone)
               availability_zone = "#{config[:region]}#{availability_zone}"
             end
             i[:placement] = { availability_zone: availability_zone.downcase }

--- a/lib/kitchen/driver/aws/standard_platform/amazon.rb
+++ b/lib/kitchen/driver/aws/standard_platform/amazon.rb
@@ -39,7 +39,7 @@ module Kitchen
           end
 
           def self.from_image(driver, image)
-            if image.name =~ /amzn-ami/i
+            if /amzn-ami/i.match?(image.name)
               image.name =~ /\b(\d+(\.\d+[\.\d])?)/i
               new(driver, "amazon", (Regexp.last_match || [])[1], image.architecture)
             end

--- a/lib/kitchen/driver/aws/standard_platform/amazon2.rb
+++ b/lib/kitchen/driver/aws/standard_platform/amazon2.rb
@@ -39,7 +39,7 @@ module Kitchen
           end
 
           def self.from_image(driver, image)
-            if image.name =~ /amzn2-ami/i
+            if /amzn2-ami/i.match?(image.name)
               image.name =~ /\b(\d+(\.\d+[\.\d])?)/i
               new(driver, "amazon2", (Regexp.last_match || [])[1], image.architecture)
             end

--- a/lib/kitchen/driver/aws/standard_platform/centos.rb
+++ b/lib/kitchen/driver/aws/standard_platform/centos.rb
@@ -75,7 +75,7 @@ module Kitchen
           end
 
           def self.from_image(driver, image)
-            if image.name =~ /centos/i
+            if /centos/i.match?(image.name)
               image.name =~ /\b(\d+(\.\d+)?)\b/i
               new(driver, "centos", (Regexp.last_match || [])[1], image.architecture)
             end

--- a/lib/kitchen/driver/aws/standard_platform/debian.rb
+++ b/lib/kitchen/driver/aws/standard_platform/debian.rb
@@ -60,7 +60,7 @@ module Kitchen
           end
 
           def self.from_image(driver, image)
-            if image.name =~ /debian/i
+            if /debian/i.match?(image.name)
               image.name =~ /\b(\d+|#{DEBIAN_CODENAMES.values.join("|")})\b/i
               version = (Regexp.last_match || [])[1]
               if version && version.to_i == 0

--- a/lib/kitchen/driver/aws/standard_platform/fedora.rb
+++ b/lib/kitchen/driver/aws/standard_platform/fedora.rb
@@ -39,7 +39,7 @@ module Kitchen
           end
 
           def self.from_image(driver, image)
-            if image.name =~ /fedora/i
+            if /fedora/i.match?(image.name)
               image.name =~ /\b(\d+(\.\d+)?)\b/i
               new(driver, "fedora", (Regexp.last_match || [])[1], image.architecture)
             end

--- a/lib/kitchen/driver/aws/standard_platform/freebsd.rb
+++ b/lib/kitchen/driver/aws/standard_platform/freebsd.rb
@@ -41,7 +41,7 @@ module Kitchen
           end
 
           def self.from_image(driver, image)
-            if image.name =~ /freebsd/i
+            if /freebsd/i.match?(image.name)
               image.name =~ /\b(\d+(\.\d+)?)\b/i
               new(driver, "freebsd", (Regexp.last_match || [])[1], image.architecture)
             end

--- a/lib/kitchen/driver/aws/standard_platform/rhel.rb
+++ b/lib/kitchen/driver/aws/standard_platform/rhel.rb
@@ -45,7 +45,7 @@ module Kitchen
           end
 
           def self.from_image(driver, image)
-            if image.name =~ /rhel/i
+            if /rhel/i.match?(image.name)
               image.name =~ /\b(\d+(\.\d+)?)/i
               new(driver, "rhel", (Regexp.last_match || [])[1], image.architecture)
             end

--- a/lib/kitchen/driver/aws/standard_platform/ubuntu.rb
+++ b/lib/kitchen/driver/aws/standard_platform/ubuntu.rb
@@ -39,7 +39,7 @@ module Kitchen
           end
 
           def self.from_image(driver, image)
-            if image.name =~ /ubuntu/i
+            if /ubuntu/i.match?(image.name)
               image.name =~ /\b(\d+(\.\d+)?)\b/i
               new(driver, "ubuntu", (Regexp.last_match || [])[1], image.architecture)
             end

--- a/lib/kitchen/driver/aws/standard_platform/windows.rb
+++ b/lib/kitchen/driver/aws/standard_platform/windows.rb
@@ -70,7 +70,7 @@ module Kitchen
           end
 
           def self.from_image(driver, image)
-            if image.name =~ /Windows/i
+            if /Windows/i.match?(image.name)
               # 2008 R2 SP2
               if image.name =~ /(\b\d+)\W*(r\d+)?/i
                 major, revision = (Regexp.last_match || [])[1], (Regexp.last_match || [])[2]

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -260,7 +260,7 @@ module Kitchen
 
         info("EC2 instance <#{state[:server_id]}> ready (hostname: #{state[:hostname]}).")
         instance.transport.connection(state).wait_until_ready
-        create_ec2_json(state) if instance.provisioner.name =~ /chef/i
+        create_ec2_json(state) if /chef/i.match?(instance.provisioner.name)
         debug("ec2:create '#{state[:hostname]}'")
       rescue Exception
         # Clean up any auto-created security groups or keys on the way out.


### PR DESCRIPTION
If we don't need the match data then let's not allocate that data.

Signed-off-by: Tim Smith <tsmith@chef.io>