### PR TITLE
Allow multiple ip addresses to be specified when creating a security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ security_group_filter:
     value: 'MyOtherSG'
 ```
 
-#### `security_group_cidr_ips`
+#### `security_group_cidr_ip`
 
-An Array of EC2 [security group][group_docs] ip(s), in CIDR block format, to use when creating the security group.
+The EC2 [security group][group_docs] ip address, in CIDR block format, to use when creating the security group. Optionally, you can provide an array of ip addresses instead when having multiple ip addresses for the security group is desirable.
 
-The default is ["0.0.0.0/0"].
+The default is "0.0.0.0/0".
 
 #### `region`
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ security_group_filter:
 
 #### `security_group_cidr_ips`
 
-The EC2 [security group][group_docs] ip(s), in CIDR block format, to use when creating the security group.
+An Array of EC2 [security group][group_docs] ip(s), in CIDR block format, to use when creating the security group.
 
 The default is ["0.0.0.0/0"].
 

--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ security_group_filter:
     value: 'MyOtherSG'
 ```
 
-### `security_group_cidr_ip`
+#### `security_group_cidr_ips`
 
-The EC2 [security group][group_docs] ip, in CIDR block format, to use when creating the security group.
+The EC2 [security group][group_docs] ip(s), in CIDR block format, to use when creating the security group.
 
-The default is "0.0.0.0/0".
+The default is ["0.0.0.0/0"].
 
 #### `region`
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -59,7 +59,7 @@ module Kitchen
       default_config :ebs_optimized,      false
       default_config :security_group_ids, nil
       default_config :security_group_filter, nil
-      default_config :security_group_cidr_ip, "0.0.0.0/0"
+      default_config :security_group_cidr_ips, ["0.0.0.0/0"]
       default_config :tags, "created-by" => "test-kitchen"
       default_config :user_data do |driver|
         if driver.windows_os?
@@ -785,7 +785,9 @@ module Kitchen
               ip_protocol: "tcp",
               from_port: port,
               to_port: port,
-              ip_ranges: [{ cidr_ip: config[:security_group_cidr_ip] }],
+              ip_ranges: config[:security_group_cidr_ips].map do |cidr_ip|
+                { cidr_ip: cidr_ip }
+              end
             }
           end
         )

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -787,7 +787,7 @@ module Kitchen
               to_port: port,
               ip_ranges: config[:security_group_cidr_ips].map do |cidr_ip|
                 { cidr_ip: cidr_ip }
-              end
+              end,
             }
           end
         )

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -59,7 +59,7 @@ module Kitchen
       default_config :ebs_optimized,      false
       default_config :security_group_ids, nil
       default_config :security_group_filter, nil
-      default_config :security_group_cidr_ips, ["0.0.0.0/0"]
+      default_config :security_group_cidr_ip, "0.0.0.0/0"
       default_config :tags, "created-by" => "test-kitchen"
       default_config :user_data do |driver|
         if driver.windows_os?
@@ -785,7 +785,7 @@ module Kitchen
               ip_protocol: "tcp",
               from_port: port,
               to_port: port,
-              ip_ranges: config[:security_group_cidr_ips].map do |cidr_ip|
+              ip_ranges: Array(config[:security_group_cidr_ip]).map do |cidr_ip|
                 { cidr_ip: cidr_ip }
               end,
             }

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -550,9 +550,9 @@ describe Kitchen::Driver::Ec2 do
         include_examples "common create"
       end
 
-      context "with a ip address configured" do
+      context "with an ip address configured as a string" do
         before do
-          config[:security_group_cidr_ips] = ["1.2.3.4/32"]
+          config[:security_group_cidr_ip] = "1.2.3.4/32"
           expect(actual_client).to receive(:describe_subnets).with(filters: [{ name: "subnet-id", values: ["subnet-1234"] }]).and_return(double(subnets: [double(vpc_id: "vpc-1")]))
           expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: "vpc-1").and_return(double(group_id: "sg-9876"))
           expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: "sg-9876", ip_permissions: [
@@ -566,9 +566,25 @@ describe Kitchen::Driver::Ec2 do
         include_examples "common create"
       end
 
-      context "with multiple ip addresses configured" do
+      context "with an ip address configured as an array" do
         before do
-          config[:security_group_cidr_ips] = ["10.0.0.0/22", "172.16.0.0/24"]
+          config[:security_group_cidr_ip] = ["10.0.0.0/22"]
+          expect(actual_client).to receive(:describe_subnets).with(filters: [{ name: "subnet-id", values: ["subnet-1234"] }]).and_return(double(subnets: [double(vpc_id: "vpc-1")]))
+          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: "vpc-1").and_return(double(group_id: "sg-9876"))
+          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: "sg-9876", ip_permissions: [
+            { ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }] },
+            { ip_protocol: "tcp", from_port: 3389, to_port: 3389, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }] },
+            { ip_protocol: "tcp", from_port: 5985, to_port: 5985, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }] },
+            { ip_protocol: "tcp", from_port: 5986, to_port: 5986, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }] },
+          ])
+        end
+
+        include_examples "common create"
+      end
+
+      context "with multiple ip addresses configured as an array" do
+        before do
+          config[:security_group_cidr_ip] = ["10.0.0.0/22", "172.16.0.0/24"]
           expect(actual_client).to receive(:describe_subnets).with(filters: [{ name: "subnet-id", values: ["subnet-1234"] }]).and_return(double(subnets: [double(vpc_id: "vpc-1")]))
           expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: "vpc-1").and_return(double(group_id: "sg-9876"))
           expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: "sg-9876", ip_permissions: [

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -552,7 +552,7 @@ describe Kitchen::Driver::Ec2 do
 
       context "with a ip address configured" do
         before do
-          config[:security_group_cidr_ip] = "1.2.3.4/32"
+          config[:security_group_cidr_ips] = ["1.2.3.4/32"]
           expect(actual_client).to receive(:describe_subnets).with(filters: [{ name: "subnet-id", values: ["subnet-1234"] }]).and_return(double(subnets: [double(vpc_id: "vpc-1")]))
           expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: "vpc-1").and_return(double(group_id: "sg-9876"))
           expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: "sg-9876", ip_permissions: [
@@ -560,6 +560,22 @@ describe Kitchen::Driver::Ec2 do
             { ip_protocol: "tcp", from_port: 3389, to_port: 3389, ip_ranges: [{ cidr_ip: "1.2.3.4/32" }] },
             { ip_protocol: "tcp", from_port: 5985, to_port: 5985, ip_ranges: [{ cidr_ip: "1.2.3.4/32" }] },
             { ip_protocol: "tcp", from_port: 5986, to_port: 5986, ip_ranges: [{ cidr_ip: "1.2.3.4/32" }] },
+          ])
+        end
+
+        include_examples "common create"
+      end
+
+      context "with multiple ip addresses configured" do
+        before do
+          config[:security_group_cidr_ips] = ["10.0.0.0/22", "172.16.0.0/24"]
+          expect(actual_client).to receive(:describe_subnets).with(filters: [{ name: "subnet-id", values: ["subnet-1234"] }]).and_return(double(subnets: [double(vpc_id: "vpc-1")]))
+          expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: "vpc-1").and_return(double(group_id: "sg-9876"))
+          expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: "sg-9876", ip_permissions: [
+            { ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
+            { ip_protocol: "tcp", from_port: 3389, to_port: 22, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
+            { ip_protocol: "tcp", from_port: 5985, to_port: 22, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
+            { ip_protocol: "tcp", from_port: 5986, to_port: 22, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
           ])
         end
 

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -573,9 +573,9 @@ describe Kitchen::Driver::Ec2 do
           expect(actual_client).to receive(:create_security_group).with(group_name: /kitchen-/, description: /Test Kitchen for/, vpc_id: "vpc-1").and_return(double(group_id: "sg-9876"))
           expect(actual_client).to receive(:authorize_security_group_ingress).with(group_id: "sg-9876", ip_permissions: [
             { ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
-            { ip_protocol: "tcp", from_port: 3389, to_port: 22, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
-            { ip_protocol: "tcp", from_port: 5985, to_port: 22, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
-            { ip_protocol: "tcp", from_port: 5986, to_port: 22, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
+            { ip_protocol: "tcp", from_port: 3389, to_port: 3389, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
+            { ip_protocol: "tcp", from_port: 5985, to_port: 5985, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
+            { ip_protocol: "tcp", from_port: 5986, to_port: 5986, ip_ranges: [{ cidr_ip: "10.0.0.0/22" }, { cidr_ip: "172.16.0.0/24" }] },
           ])
         end
 


### PR DESCRIPTION
# Description

Allow `security_group_cidr_ip` option to accept either a string or an array. By providing an array, the user can specify multiple IP addresses for the security group. The default value stays the same `0.0.0.0/0`.

Currently, `security_group_cidr_ip` option only allows one ip address to be added to the temporary security group. Oftentimes, allowing more than one ip address is necessary because load balancers in cloud have multiple ips that change frequently. For instance, when test-kitchen runs on TravisCI, the temporary security group created by kitchen-ec2 should include all the public ips of Travis since kitchen on Travis should be able to connect to a test instance on your AWS VPC. Using an existing security group with hard-coded public ips is not ideal because their public ips are dynamic and can change.
TravisCI public ip info: https://docs.travis-ci.com/user/ip-addresses/

## Issues Resolved

n/a

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
