### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ end
 desc "Run all quality tasks"
 task quality: %i{style stats}
 
-require "yard"
+require "yard" unless defined?(YARD)
 YARD::Rake::YardocTask.new
 
 task default: %i{test quality style}

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "base64"
+require "base64" unless defined?(Base64)
 require "aws-sdk-ec2"
 
 module Kitchen

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "benchmark"
-require "json"
+require "benchmark" unless defined?(Benchmark)
+require "json" unless defined?(JSON)
 require "kitchen"
 require_relative "ec2_version"
 require_relative "aws/client"
@@ -34,10 +34,10 @@ require_relative "aws/standard_platform/ubuntu"
 require_relative "aws/standard_platform/windows"
 require "aws-sdk-ec2"
 require "aws-sdk-core/waiters/errors"
-require "retryable"
-require "time"
-require "etc"
-require "socket"
+require "retryable" unless defined?(Retryable)
+require "time" unless defined?(Time)
+require "etc" unless defined?(Etc)
+require "socket" unless defined?(Socket)
 
 module Kitchen
 

--- a/spec/kitchen/driver/aws/instance_generator_spec.rb
+++ b/spec/kitchen/driver/aws/instance_generator_spec.rb
@@ -18,8 +18,8 @@
 
 require "kitchen/driver/aws/instance_generator"
 require "kitchen/driver/aws/client"
-require "tempfile"
-require "base64"
+require "tempfile" unless defined?(Tempfile)
+require "base64" unless defined?(Base64)
 require "aws-sdk-ec2"
 
 describe Kitchen::Driver::Aws::InstanceGenerator do


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>