### PR TITLE
Use defaults when creating spot instances - fixes block_duration_minutes

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -473,7 +473,6 @@ module Kitchen
         debug("Creating EC2 Spot Instance..")
         instance_data = instance_generator.ec2_instance_data
 
-        request_duration = config[:spot_wait]
         config_spot_price = config[:spot_price].to_s
         if %w{ondemand on-demand}.include?(config_spot_price)
           spot_price = ""
@@ -481,9 +480,10 @@ module Kitchen
           spot_price = config_spot_price
         end
         spot_options = {
-          spot_instance_type: "persistent", # Cannot use one-time with valid_until
-          valid_until: Time.now + request_duration,
-          instance_interruption_behavior: "stop",
+          # Must use one-time in order to use instance_interruption_behavior=terminate
+          # spot_instance_type: "one-time", # default
+          # Must use instance_interruption_behavior=terminate in order to use block_duration_minutes
+          # instance_interruption_behavior: "terminate", # default
         }
         if config[:block_duration_minutes]
           spot_options[:block_duration_minutes] = config[:block_duration_minutes]

--- a/spec/kitchen/driver/ec2_spec.rb
+++ b/spec/kitchen/driver/ec2_spec.rb
@@ -254,7 +254,6 @@ describe Kitchen::Driver::Ec2 do
   describe "#submit_spot" do
     before do
       expect(driver).to receive(:instance).at_least(:once).and_return(instance)
-      allow(Time).to receive(:now).and_return(Time.now)
     end
 
     it "submits the server request" do
@@ -263,9 +262,6 @@ describe Kitchen::Driver::Ec2 do
         instance_market_options: {
           market_type: "spot",
           spot_options: {
-            spot_instance_type: "persistent",
-            instance_interruption_behavior: "stop",
-            valid_until: Time.now + config[:spot_wait],
             block_duration_minutes: 60,
           },
         }


### PR DESCRIPTION
# Description

This switches back to creating one-time requests and terminate on
interrupt, which is the default behavior. That is needed so that
the block_duration_minutes feature will work with the API. The
non-default settings were being used in an attempt to use the
valid_until setting, but we are already honoring the spot_wait
setting by using it in the retry.

## Issues Resolved

Fixes #511 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
