### PR TITLE
Update for GP3 Support

### DIFF
--- a/lib/kitchen/driver/aws/standard_platform.rb
+++ b/lib/kitchen/driver/aws/standard_platform.rb
@@ -210,10 +210,10 @@ module Kitchen
           images = images.sort_by(&:creation_date).reverse
           # P5: We prefer x86_64 over i386 (if available)
           images = prefer(images) { |image| image.architecture == "x86_64" }
-          # P4: We prefer gp2 (SSD) (if available)
+          # P4: We prefer (SSD) (if available)
           images = prefer(images) do |image|
             image.block_device_mappings.any? do |b|
-              b.device_name == image.root_device_name && b.ebs && b.ebs.volume_type == "gp2"
+              b.device_name == image.root_device_name && b.ebs && %w{gp3 gp2}.any? { |t| b.ebs.volume_type == t }
             end
           end
           # P3: We prefer ebs over instance_store (if available)


### PR DESCRIPTION
# Description

I noticed that my kitchens were not choosing the latest AMI within my org.  This is because I have swapped their build processes over to GP3.  

## Issues Resolved

Will now pick up latest image properly if it uses a GP3 volume type.

The current workaround is to include:
```yaml
    driver:
      image_search:
        block-device-mapping.volume-type: gp3
        ....
```

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.

CC: @chefbob