### PR TITLE
Require Ruby 2.5 + misc test cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Lint/IneffectiveAccessModifier:
   Exclude:

--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,2 @@
 --readme README.md
 --markup markdown
---markup-provider maruku

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Please refer to the Chef Community Code of Conduct at https://www.chef.io/code-of-conduct/

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,11 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "rake"
+  gem "rake", ">= 11.0"
+  gem "rspec", "~> 3.2"
+end
+
+group :debug do
   gem "pry"
 end
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # <a name="title"></a> Kitchen::Ec2: A Test Kitchen Driver for Amazon EC2
 
 [![Gem Version](https://badge.fury.io/rb/kitchen-ec2.svg)](https://badge.fury.io/rb/kitchen-ec2)
-![CI](https://github.com/test-kitchen/kitchen-ec2/workflows/CI/badge.svg)
-[![Code Climate](https://codeclimate.com/github/test-kitchen/kitchen-ec2/badges/gpa.svg)](https://codeclimate.com/github/test-kitchen/kitchen-ec2)
+![CI](https://github.com/test-kitchen/kitchen-ec2/workflows/CI/badge.svg?branch=master)
 
 A [Test Kitchen][kitchenci] Driver for Amazon EC2.
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,4 @@ rescue LoadError
   puts "chefstyle is not available. (sudo) gem install chefstyle to do style checking."
 end
 
-desc "Run all quality tasks"
-
 task default: %i{test style}

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^lib/)
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.4"
+  gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "test-kitchen", ">= 1.4.1", "< 3"
   gem.add_dependency "aws-sdk-ec2", "~> 1.0"

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rspec",     "~> 3.2"
   gem.add_development_dependency "maruku",    "~> 0.6"
-  gem.add_development_dependency "climate_control"
 end

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -20,6 +20,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency "test-kitchen", ">= 1.4.1", "< 3"
   gem.add_dependency "aws-sdk-ec2", "~> 1.0"
   gem.add_dependency "retryable", ">= 2.0", "< 4.0" # 4.0 will need to be validated
-
-  gem.add_development_dependency "rspec",     "~> 3.2"
 end

--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency "retryable", ">= 2.0", "< 4.0" # 4.0 will need to be validated
 
   gem.add_development_dependency "rspec",     "~> 3.2"
-  gem.add_development_dependency "maruku",    "~> 0.6"
 end

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -459,12 +459,10 @@ module Kitchen
 
         errs = []
         configs.each do |conf|
-          begin
-            @config = conf
-            return submit_spot
-          rescue => e
-            errs.append(e)
-          end
+          @config = conf
+          return submit_spot
+        rescue => e
+          errs.append(e)
         end
         raise ["Could not create a spot instance:", errs].flatten.join("\n")
       end

--- a/spec/kitchen/driver/aws/client_spec.rb
+++ b/spec/kitchen/driver/aws/client_spec.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 
 require "kitchen/driver/aws/client"
-require "climate_control"
 
 describe Kitchen::Driver::Aws::Client do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,11 +18,6 @@
 
 require "support/fake_image"
 
-if ENV["CODECLIMATE_REPO_TOKEN"]
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
-end
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Require a supported Ruby release (2.5)
Move dev deps to the gemfile
Add a code of conduct file
Remove Code Climate setup
Remove dep for yard markdown processing