### PR TITLE
setting true as default for delete_on_termination

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -56,8 +56,8 @@ module Kitchen
       default_config :shared_credentials_profile, ENV["AWS_PROFILE"]
       default_config :availability_zone, nil
       default_config :instance_type, &:default_instance_type
-      default_config :ebs_optimized,      false
-      default_config :delete_on_termination,      true
+      default_config :ebs_optimized, false
+      default_config :delete_on_termination, true
       default_config :security_group_ids, nil
       default_config :security_group_filter, nil
       default_config :security_group_cidr_ip, "0.0.0.0/0"

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -57,6 +57,7 @@ module Kitchen
       default_config :availability_zone, nil
       default_config :instance_type, &:default_instance_type
       default_config :ebs_optimized,      false
+      default_config :delete_on_termination,      true
       default_config :security_group_ids, nil
       default_config :security_group_filter, nil
       default_config :security_group_cidr_ip, "0.0.0.0/0"


### PR DESCRIPTION
Signed-off-by: Pranay Singh <i5singh.pranay@gmail.com>

# Description
 EC2 instance root volume gets deleted after terminating an ec2 instance that uses this CentoOS AMI.
## Issues Resolved
fixes https://github.com/test-kitchen/kitchen-ec2/issues/401

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
