### PR TITLE
Add support for Windows Server 2022

### DIFF
--- a/lib/kitchen/driver/aws/standard_platform/windows.rb
+++ b/lib/kitchen/driver/aws/standard_platform/windows.rb
@@ -134,7 +134,7 @@ module Kitchen
 
           def windows_name_filter # rubocop:disable Metrics/MethodLength
             major, revision, service_pack = windows_version_parts
-            if major == 2019 || major == 2016
+            if major == 2022 || major == 2019 || major == 2016
               "Windows_Server-#{major}-English-Full-Base-*"
             elsif major == 1709 || major == 1803
               "Windows_Server-#{major}-English-Core-ContainersLatest-*"


### PR DESCRIPTION
# Description

Add support for Windows Server 2022

https://aws.amazon.com/about-aws/whats-new/2021/09/aws-microsoft-windows-server-2022-amazon-ec2/

## Issues Resolved

N/A I dont think

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
