### PR TITLE
Adds support for defining multiple tags for `subnet_filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,15 +255,22 @@ The default is unset, or `nil`.
 
 #### `subnet_filter`
 
-The EC2 [subnet][subnet_docs] to use, specified by tag.
-
+The EC2 [subnet][subnet_docs] to use, specified by tag(s).
 The default is unset, or `nil`.
 
 An example of usage:
 ```yaml
+# By Tag
 subnet_filter:
   tag:   'Name'
   value: 'example-subnet-name'
+
+# Multiple Tags
+subnet_filter:
+  - tag:   'Type'
+    value: 'application'
+  - tag:   'Environment'
+    value: 'dev'
 ```
 
 #### `tags`
@@ -272,6 +279,17 @@ The Hash of EC tag name/value pairs which will be applied to the instance.
 
 The default is `{ "created-by" => "test-kitchen" }`.
 
+An example of usage:
+```yaml
+# Single tag
+tags:
+  created-by: 'test-kitchen'
+
+# Multiple Tags
+tags:
+  created-by: 'test-kitchen'
+  reason: 'Only used for testing can be deleted'
+```
 
 #### `user_data`
 

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -59,7 +59,7 @@ module Kitchen
             end
 
             subnets = client.describe_subnets(r).subnets
-	          raise "Subnets with tags '#{filters}' not found during security group creation" if subnets.empty?
+            raise "Subnets with tags '#{filters}' not found during security group creation" if subnets.empty?
 
             # => Select the least-populated subnet if we have multiple matches
             subnet = subnets.max_by { |s| s[:available_ip_address_count] }

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -265,9 +265,8 @@ module Kitchen
         create_ec2_json(state) if /chef/i.match?(instance.provisioner.name)
         debug("ec2:create '#{state[:hostname]}'")
       rescue Exception => e
-        # Clean up any auto-created security groups or keys on the way out.
-        delete_security_group(state)
-        delete_key(state)
+        # Clean up the instance and any auto-created security groups or keys on the way out.
+        destroy(state)
         raise "#{e.message} in the specified region #{config[:region]}. Please check this AMI is available in this region."
       end
 
@@ -433,15 +432,21 @@ module Kitchen
         else
           # => Enable cascading through matching subnets
           client = ::Aws::EC2::Client.new(region: config[:region])
-          subnets = client.describe_subnets(
-            filters: [
+
+          filters = [config[:subnet_filter]].flatten
+
+          r = { filters: [] }
+          filters.each do |subnet_filter|
+            r[:filters] <<
               {
-                name: "tag:#{config[:subnet_filter][:tag]}",
-                values: [config[:subnet_filter][:value]],
-              },
-            ]
-          ).subnets
-          raise "A subnet matching '#{config[:subnet_filter][:tag]}:#{config[:subnet_filter][:value]}' does not exist!" unless subnets.any?
+                name: "tag:#{subnet_filter[:tag]}",
+                values: [subnet_filter[:value]],
+              }
+          end
+
+          subnets = ec2.client.describe_subnets(r).subnets
+
+          raise "Subnets with tags '#{filters}' not found!" if subnets.empty?
 
           configs = subnets.map do |subnet|
             new_config = config.clone
@@ -751,8 +756,19 @@ module Kitchen
 
                    subnets.first.vpc_id
                  elsif config[:subnet_filter]
-                   subnets = ec2.client.describe_subnets(filters: [{ name: "tag:#{config[:subnet_filter][:tag]}", values: [config[:subnet_filter][:value]] }]).subnets
-                   raise "Subnets with tag '#{config[:subnet_filter][:tag]}=#{config[:subnet_filter][:value]}' not found during security group creation" if subnets.empty?
+                   filters = [config[:subnet_filter]].flatten
+
+                   r = { filters: [] }
+                   filters.each do |subnet_filter|
+                     r[:filters] << {
+                       name: "tag:#{subnet_filter[:tag]}",
+                       values: [subnet_filter[:value]],
+                     }
+                   end
+
+                   subnets = ec2.client.describe_subnets(r).subnets
+
+                   raise "Subnets with tags '#{filters}' not found during security group creation" if subnets.empty?
 
                    subnets.first.vpc_id
                  else

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -444,7 +444,7 @@ module Kitchen
               }
           end
 
-          subnets = ec2.client.describe_subnets(r).subnets
+          subnets = client.describe_subnets(r).subnets
 
           raise "Subnets with tags '#{filters}' not found!" if subnets.empty?
 


### PR DESCRIPTION
# Description

- Adds support for defining multiple tags for `subnet_filter`
- Ensure instance is terminated if a failure occurs during creation
- Adds documentation for specifying multiple tags

## Issues Resolved

#411 #555 

List any existing issues this PR resolves

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
