### PR TITLE
Optionally enforce IMDSv2 on kitchen instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ driver:
 
 elastic_network_interface_id's have a format like eni-0545666738adeed14. You can only attach the network interface to instances in the same Availability Zone.
 
+#### `enforce_imdsv2`
+
+Setting this boolean to `true` will enforce IMDSv2 on kitchen instances. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html for more information on IMDS. Defaults to `false`
+
 ### Disk Configuration
 
 #### <a name="config-block_device_mappings"></a> `block_device_mappings`

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -196,6 +196,13 @@ module Kitchen
               config[:instance_initiated_shutdown_behavior].empty?
             i[:instance_initiated_shutdown_behavior] = config[:instance_initiated_shutdown_behavior]
           end
+          if config[:enforce_imdsv2]
+            i[:metadata_options] = {
+              http_endpoint: "enabled",
+              http_tokens: "required",
+              http_put_response_hop_limit: 1,
+            }
+          end
           i
         end
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -89,6 +89,7 @@ module Kitchen
       default_config :instance_initiated_shutdown_behavior, nil
       default_config :ssl_verify_peer, true
       default_config :skip_cost_warning, false
+      default_config :enforce_imdsv2, false
 
       def initialize(*args, &block)
         super

--- a/spec/kitchen/driver/aws/instance_generator_spec.rb
+++ b/spec/kitchen/driver/aws/instance_generator_spec.rb
@@ -720,5 +720,37 @@ describe Kitchen::Driver::Aws::InstanceGenerator do
         )
       end
     end
+
+    context "when enforcing IMDSv2" do
+      let(:config) do
+        {
+          region: "us-east-1",
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          subnet_id: "s-456",
+          private_ip_address: "0.0.0.0",
+          enforce_imdsv2: true,
+        }
+      end
+
+      it "returns the correct metadata" do
+        expect(generator.ec2_instance_data).to eq(
+          instance_type: "micro",
+          ebs_optimized: true,
+          image_id: "ami-123",
+          key_name: nil,
+          subnet_id: "s-456",
+          private_ip_address: "0.0.0.0",
+          metadata_options: {
+            http_endpoint: "enabled",
+            http_tokens: "required",
+            http_put_response_hop_limit: 1,
+          },
+          max_count: 1,
+          min_count: 1
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
# Description

Provides an option to enforce IMDSv2 on kitchen instances.

I considered exposing metadata_options directly but this brings it in line with the way it's done in the AWS console.

## Issues Resolved

https://github.com/test-kitchen/kitchen-ec2/issues/479

## Check List

- [X] All tests pass. See TESTING.md for details. 
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
