### PR TITLE
Add support for metadata_options

### DIFF
--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -153,6 +153,7 @@ module Kitchen
             i[:block_device_mappings] = config[:block_device_mappings]
           end
           i[:security_group_ids] = Array(config[:security_group_ids]) if config[:security_group_ids]
+          i[:metadata_options] = config[:metadata_options] if config[:metadata_options]
           i[:user_data] = prepared_user_data if prepared_user_data
           if config[:iam_profile_name]
             i[:iam_instance_profile] = { name: config[:iam_profile_name] }


### PR DESCRIPTION
# Description

Support for configuring IMDSv2.  Also exposes configuration for enabling instance tags via IMDS.

https://aws.amazon.com/about-aws/whats-new/2022/01/instance-tags-amazon-ec2-instance-metadata-service/


## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
