### PR TITLE
Use chefstyle linting

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -27,4 +27,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake style
+      - uses: r7kamura/rubocop-problem-matchers-action@v1
+      - run: bundle exec chefstyle


### PR DESCRIPTION
Signed-off-by: sachin007jain <sachin.jain@chef.io>

Using Chefstyle for linting instead of Rubocop

Describe what this change achieves

- https://github.com/chef/chef-workstation/issues/2522

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
