### PR TITLE
Improve speed of readiness detection for Windows instances

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -251,14 +251,6 @@ module Kitchen
           wait_until_ready(server, state)
         end
 
-        if windows_os? &&
-            instance.transport[:username] =~ /administrator/i &&
-            instance.transport[:password].nil?
-          # If we're logging into the administrator user and a password isn't
-          # supplied, try to fetch it from the AWS instance
-          fetch_windows_admin_password(server, state)
-        end
-
         info("EC2 instance <#{state[:server_id]}> ready (hostname: #{state[:hostname]}).")
         instance.transport.connection(state).wait_until_ready
         attach_network_interface(state) unless config[:elastic_network_interface_id].nil?
@@ -536,8 +528,7 @@ module Kitchen
             state[:hostname] = hostname(aws_instance, nil)
           end
           if ready && windows_os?
-            if windows_os? &&
-                instance.transport[:username] =~ /administrator/i &&
+            if instance.transport[:username] =~ /administrator/i &&
                 instance.transport[:password].nil?
               # If we're logging into the administrator user and a password isn't
               # supplied, try to fetch it from the AWS instance

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -537,8 +537,8 @@ module Kitchen
           end
           if ready && windows_os?
             if windows_os? &&
-              instance.transport[:username] =~ /administrator/i &&
-              instance.transport[:password].nil?
+                instance.transport[:username] =~ /administrator/i &&
+                instance.transport[:password].nil?
               # If we're logging into the administrator user and a password isn't
               # supplied, try to fetch it from the AWS instance
               fetch_windows_admin_password(server, state)
@@ -758,38 +758,38 @@ module Kitchen
 
         # Work out which VPC, if any, we are creating in.
         vpc_id = if config[:subnet_id]
-          # Get the VPC ID for the subnet.
-          subnets = ec2.client.describe_subnets(filters: [{ name: "subnet-id", values: [config[:subnet_id]] }]).subnets
-          raise "Subnet #{config[:subnet_id]} not found during security group creation" if subnets.empty?
+                   # Get the VPC ID for the subnet.
+                   subnets = ec2.client.describe_subnets(filters: [{ name: "subnet-id", values: [config[:subnet_id]] }]).subnets
+                   raise "Subnet #{config[:subnet_id]} not found during security group creation" if subnets.empty?
 
-          subnets.first.vpc_id
-        elsif config[:subnet_filter]
-          filters = [config[:subnet_filter]].flatten
+                   subnets.first.vpc_id
+                 elsif config[:subnet_filter]
+                   filters = [config[:subnet_filter]].flatten
 
-          r = { filters: [] }
-          filters.each do |subnet_filter|
-            r[:filters] << {
-              name: "tag:#{subnet_filter[:tag]}",
-              values: [subnet_filter[:value]],
-            }
-          end
+                   r = { filters: [] }
+                   filters.each do |subnet_filter|
+                     r[:filters] << {
+                       name: "tag:#{subnet_filter[:tag]}",
+                       values: [subnet_filter[:value]],
+                     }
+                   end
 
-          subnets = ec2.client.describe_subnets(r).subnets
+                   subnets = ec2.client.describe_subnets(r).subnets
 
-          raise "Subnets with tags '#{filters}' not found during security group creation" if subnets.empty?
+                   raise "Subnets with tags '#{filters}' not found during security group creation" if subnets.empty?
 
-          subnets.first.vpc_id
-        else
-          # Try to check for a default VPC.
-          vpcs = ec2.client.describe_vpcs(filters: [{ name: "isDefault", values: ["true"] }]).vpcs
-          if vpcs.empty?
-            # No default VPC so assume EC2-Classic ¯\_(ツ)_/¯
-            nil
-          else
-            # I don't actually know if you can have more than one default VPC?
-            vpcs.first.vpc_id
-          end
-        end
+                   subnets.first.vpc_id
+                 else
+                   # Try to check for a default VPC.
+                   vpcs = ec2.client.describe_vpcs(filters: [{ name: "isDefault", values: ["true"] }]).vpcs
+                   if vpcs.empty?
+                     # No default VPC so assume EC2-Classic ¯\_(ツ)_/¯
+                     nil
+                   else
+                     # I don't actually know if you can have more than one default VPC?
+                     vpcs.first.vpc_id
+                   end
+                 end
         # Create the SG.
         params = {
           group_name: "kitchen-#{Array.new(8) { rand(36).to_s(36) }.join}",


### PR DESCRIPTION
Move the fetching of the Windows admin password into the `wait_until_ready` function to speed up readiness detection of Windows instances

# Description

In instances where the administrative username/password is not defined by the user, if we change the Windows instance readiness detection to use the retrieval of the admin password as a readiness factor rather than the console output, we can speed up the readiness detection for Windows instances by 4+ minutes.

In my testing:

- with a c6i.large, the instance took ~60 seconds to become "ready" (~20 seconds to become "running" and ~40 seconds to retrieve the password)
- with a t3a.nano, the instance took ~80 seconds to become "ready" (~10 seconds to become "running" and ~70 seconds to retrieve the password)

In contrast to the existing logic:

- with a c6i.large, the instance took ~310 seconds to become "ready"
- with a t3a.nano, the instance took ~350 seconds to become "ready"

## Issues Resolved

#575 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
