### PR TITLE
Fix issue on failing create action

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -559,7 +559,7 @@ module Kitchen
               # supplied, try to fetch it from the AWS instance
               fetch_windows_admin_password(server, state)
             else
-              output = server.console_output.output
+              output = server.console_output.output || ''
               unless output.nil?
                 output = Base64.decode64(output)
                 debug "Console output: --- \n#{output}"


### PR DESCRIPTION
This fixes the issue when sometimes the server returns `'Message: Failed to complete #create action: [undefined method include? for nil:NilClass in the specified region us-east-1. Please check this AMI is available in this region.]`

This issue was introduced from
[here](https://github.com/test-kitchen/kitchen-ec2/compare/v3.17.0...v3.17.1#diff-5f36235c5a4a35dba130d480e2175640f7762d7ae859ad98efa704c4db646b4fR567)

# Description

Please describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
