### PR TITLE
fix: Update CentOS for username change on 9+

### DIFF
--- a/lib/kitchen/driver/aws/standard_platform/centos.rb
+++ b/lib/kitchen/driver/aws/standard_platform/centos.rb
@@ -28,7 +28,7 @@ module Kitchen
           # default username for this platform's ami
           # @return [String]
           def username
-            "centos"
+            version && version.to_f < 9.0 ? "centos" : "ec2-user"
           end
 
           def image_search

--- a/spec/kitchen/driver/aws/image_selection_spec.rb
+++ b/spec/kitchen/driver/aws/image_selection_spec.rb
@@ -131,6 +131,14 @@ describe "Default images for various platforms" do
       { name: "owner-id", values: %w{125523088429} },
       { name: "name", values: ["CentOS *", "CentOS-*-GA-*", "CentOS Linux *", "CentOS Stream *"] },
     ],
+    "centos-10" => [
+      { name: "owner-id", values: %w{125523088429} },
+      { name: "name", values: ["CentOS 10*", "CentOS-10*-GA-*", "CentOS Linux 10*", "CentOS Stream 10*"] },
+    ],
+    "centos-9" => [
+      { name: "owner-id", values: %w{125523088429} },
+      { name: "name", values: ["CentOS 9*", "CentOS-9*-GA-*", "CentOS Linux 9*", "CentOS Stream 9*"] },
+    ],
     "centos-8" => [
       { name: "owner-id", values: %w{125523088429} },
       { name: "name", values: ["CentOS 8*", "CentOS-8*-GA-*", "CentOS Linux 8*", "CentOS Stream 8*"] },


### PR DESCRIPTION
CentOS (Stream) has changed the default username on 9+ to `ec2-user` instead of `centos` in previous versions of CentOS. This commit changes the `username` to work similar to that of `rhel`, setting the user based on whether the version is less than 9.0. It also adds 9 and 10 to the standard platform spec.

Fixes #630

# Description

Please describe what this change achieves

## Issues Resolved

#630 

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
