### PR TITLE
feat: Added AWS EC2 Instance Connect support

### DIFF
--- a/kitchen-ec2.gemspec
+++ b/kitchen-ec2.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 3.1"
 
   gem.add_dependency "aws-sdk-ec2", "~> 1.0"
+  gem.add_dependency "aws-sdk-ec2instanceconnect", "~> 1.0"
   gem.add_dependency "retryable", ">= 2.0", "< 4.0" # 4.0 will need to be validated
-  gem.add_dependency "test-kitchen", ">= 1.4.1", "< 4"
+  gem.add_dependency "sshkey", "~> 2.0"
+  gem.add_dependency "test-kitchen", ">= 3.9.0", "< 4"
 end

--- a/lib/kitchen/driver/aws/instance_connect.rb
+++ b/lib/kitchen/driver/aws/instance_connect.rb
@@ -1,0 +1,44 @@
+#
+# Author:: Alex Kokkinos
+#
+# Copyright:: 2025, Alex Kokkinos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require "aws-sdk-ec2instanceconnect"
+
+module Kitchen
+  module Driver
+    class Aws
+      class InstanceConnect
+        def initialize(config, logger)
+          @config = config
+          @logger = logger
+          @client = ::Aws::EC2InstanceConnect::Client.new(region: config[:region])
+        end
+
+        def send_ssh_public_key(instance_id, username, public_key)
+          @logger.info("Sending SSH public key to instance #{instance_id} for user #{username}")
+
+          @client.send_ssh_public_key({
+            instance_id: instance_id,
+            instance_os_user: username,
+            ssh_public_key: public_key,
+            availability_zone: @config[:availability_zone],
+          })
+
+          @logger.debug("SSH public key successfully sent to instance")
+        end
+      end
+    end
+  end
+end

--- a/spec/kitchen/driver/aws/instance_connect_test.rb
+++ b/spec/kitchen/driver/aws/instance_connect_test.rb
@@ -1,0 +1,95 @@
+#
+# Author:: Alex Kokkinos
+#
+# Copyright:: 2025, Alex Kokkinos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use t his file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen/driver/aws/instance_connect"
+
+describe Kitchen::Driver::Aws::InstanceConnect do
+  let(:config) do
+    {
+      region: "us-east-1",
+      availability_zone: "us-east-1a"
+    }
+  end
+  
+  let(:logger) { instance_double("Logger") }
+  let(:aws_client) { instance_double("Aws::EC2InstanceConnect::Client") }
+  
+  let(:instance_connect) { described_class.new(config, logger) }
+  
+  before do
+    allow(::Aws::EC2InstanceConnect::Client).to receive(:new).and_return(aws_client)
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:debug)
+  end
+
+  describe "#initialize" do
+    it "sets config and logger instance variables" do
+      expect(instance_connect.instance_variable_get(:@config)).to eq(config)
+      expect(instance_connect.instance_variable_get(:@logger)).to eq(logger)
+    end
+
+    it "creates AWS EC2InstanceConnect client with correct region" do
+      expect(::Aws::EC2InstanceConnect::Client).to have_received(:new)
+        .with(region: "us-east-1")
+    end
+  end
+
+  describe "#send_ssh_public_key" do
+    let(:instance_id) { "i-1234567890abcdef0" }
+    let(:username) { "ec2-user" }
+    let(:public_key) { "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ..." }
+
+    before do
+      allow(aws_client).to receive(:send_ssh_public_key)
+    end
+
+    it "logs info message with instance details" do
+      expect(logger).to receive(:info)
+        .with("Sending SSH public key to instance #{instance_id} for user #{username}")
+      
+      instance_connect.send_ssh_public_key(instance_id, username, public_key)
+    end
+
+    it "calls AWS client with correct parameters" do
+      expected_params = {
+        instance_id: instance_id,
+        instance_os_user: username,
+        ssh_public_key: public_key,
+        availability_zone: "us-east-1a"
+      }
+
+      expect(aws_client).to receive(:send_ssh_public_key).with(expected_params)
+      
+      instance_connect.send_ssh_public_key(instance_id, username, public_key)
+    end
+
+    it "logs debug message on successful completion" do
+      expect(logger).to receive(:debug)
+        .with("SSH public key successfully sent to instance")
+      
+      instance_connect.send_ssh_public_key(instance_id, username, public_key)
+    end
+
+    it "completes the full workflow" do
+      expect(logger).to receive(:info).ordered
+      expect(aws_client).to receive(:send_ssh_public_key).ordered
+      expect(logger).to receive(:debug).ordered
+      
+      instance_connect.send_ssh_public_key(instance_id, username, public_key)
+    end
+  end
+end


### PR DESCRIPTION
# Description

Adds AWS EC2 Instance Connect support to the EC2 driver. This method utilizes a proxy managed by the Amazon EC2 Instance Connect service to connect to EC2 instances over SSH.

See also https://github.com/test-kitchen/test-kitchen/pull/2019. This feature will not work without modifying the base test kitchen tool. I have written this code in a way that attempts to keep the changes to test-kitchen minimal and not strictly EC2-specific.

## Issues Resolved

https://github.com/test-kitchen/kitchen-ec2/issues/639

## Type of Change

feat.

## Check List

- [✅] New functionality includes tests
- [✅] All tests pass
- [✅] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
