### PR TITLE
Improve SSM Session Manager: Add SSH key injection and optimize code

### DIFF
--- a/docs/ssm-session-manager.md
+++ b/docs/ssm-session-manager.md
@@ -7,7 +7,7 @@ kitchen-ec2 now supports AWS Systems Manager (SSM) Session Manager as an alterna
 - **No SSH/WinRM network access required**: Connect to instances in private subnets without VPN or bastion hosts
 - **Enhanced security**: No need to open SSH/RDP ports in security groups
 - **Centralized audit logging**: All session activity is logged to CloudTrail
-- **No SSH key management**: Eliminate the complexity of managing SSH key pairs for testing
+- **Automatic SSH key injection**: SSH keys are automatically injected into instances via SSM before each connection
 - **Zero-trust compliance**: Access instances through AWS IAM authentication instead of network-based access
 
 ## Requirements
@@ -61,8 +61,19 @@ suites:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `use_ssm_session_manager` | `false` | Enable SSM Session Manager transport |
-| `ssm_session_manager_document_name` | `nil` | Optional custom SSM document name |
+| `ssm_session_manager_document_name` | `nil` | Optional custom SSM document name eg. AWS-StartSSHSession |
 | `iam_profile_name` | `nil` | IAM instance profile (required for SSM) |
+
+## How It Works
+
+When SSM Session Manager is enabled, kitchen-ec2:
+
+1. Waits for the SSM agent to become available on the instance
+2. Automatically injects SSH public keys into the instance via SSM before each connection
+3. Configures SSH to use SSM Session Manager as a proxy command
+4. Connects to the instance through SSM, eliminating the need for direct network access
+
+SSH keys are automatically extracted from your configured key files and injected into the instance's `~/.ssh/authorized_keys` file using SSM Run Command. This happens transparently before each connection attempt.
 
 ## Additional Resources
 


### PR DESCRIPTION
- Add automatic SSH key injection via SSM before each connection
- Reuse existing code patterns from Instance Connect implementation
- Create reusable SSM command execution helper method
- Optimize SSH key injection with duplicate key prevention
- Update hostname to localhost when using SSM proxy command
- Update documentation to reflect SSH key injection functionality

# Description

Please describe what this change achieves

## Issues Resolved

The current implementation of ssm session manager is incomplete, it's not working, the connection get struck while using ssm: 
```
exec bundle exec kitchen login --log-level=debug
D      [AWS SSM Session Manager] Setting up SSM Session Manager overrides
D      Policyfile found at /Users/mayankgu/git_corp/di_infra/cookbook-prometheus/Policyfile.rb, using Policyfile to resolve cookbook dependencies
       [AWS SSM Session Manager] Using proxy command: aws ssm start-session --target i-062f944081df579ff --region us-west-2 --profile oz-dev
D      Login command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=VERBOSE -o ProxyCommand=aws ssm start-session --target i-062f944081df579ff --region us-west-2 --profile abcd -p 22 root@179.22.130.5 (Options: {})
```

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
