### PR TITLE
fix: Corrected the Amazon Linux 2023 naming convention

### DIFF
--- a/lib/kitchen/driver/aws/standard_platform/amazon2023.rb
+++ b/lib/kitchen/driver/aws/standard_platform/amazon2023.rb
@@ -32,7 +32,7 @@ module Kitchen
           def image_search
             search = {
               "owner-id" => "137112412989",
-              "name" => version ? "al2023-ami-2023.0.#{version}*" : "al2023-ami-2023.0.*",
+              "name" => version ? "al2023-ami-2023.#{version}*" : "al2023-ami-2023.*",
             }
             search["architecture"] = architecture if architecture
             search

--- a/spec/kitchen/driver/aws/image_selection_spec.rb
+++ b/spec/kitchen/driver/aws/image_selection_spec.rb
@@ -111,21 +111,21 @@ describe "Default images for various platforms" do
     ],
     "amazon2023" => [
       { name: "owner-id", values: %w{137112412989} },
-      { name: "name", values: %w{al2023-ami-2023.0.*} },
+      { name: "name", values: %w{al2023-ami-2023.*} },
     ],
     "amazon2023-x86_64" => [
       { name: "owner-id", values: %w{137112412989} },
-      { name: "name", values: %w{al2023-ami-2023.0.*} },
+      { name: "name", values: %w{al2023-ami-2023.*} },
       { name: "architecture", values: %w{x86_64} },
     ],
     "amazon2023-arm64" => [
       { name: "owner-id", values: %w{137112412989} },
-      { name: "name", values: %w{al2023-ami-2023.0.*} },
+      { name: "name", values: %w{al2023-ami-2023.*} },
       { name: "architecture", values: %w{arm64} },
     ],
-    "amazon2023-20230222" => [
+    "amazon2023-11.20260413.0" => [
       { name: "owner-id", values: %w{137112412989} },
-      { name: "name", values: %w{al2023-ami-2023.0.20230222*} },
+      { name: "name", values: %w{al2023-ami-2023.11.20260413.0*} },
     ],
     "centos" => [
       { name: "owner-id", values: %w{125523088429} },


### PR DESCRIPTION
# Description


Corrected the AMI naming convention for Amazon Linux 2023.


## Issues Resolved

Standard Platform AMI selection was no longer working for Amazon Linux 2023 after the GA images stopped being available. 

The naming / versioning convention for Amazon Linux 2023 AMIs includes quarter since GA as well and quarters are considered the minor release versions with point releases indicated by the date within that quarter. 

## Type of Change

_fix_
